### PR TITLE
Fix encryption key validation and move validation responsability to strategies

### DIFF
--- a/lib/client/strategies/api.js
+++ b/lib/client/strategies/api.js
@@ -4,6 +4,7 @@
  * @private
  */
 import { merge } from 'ramda'
+import company from '../../resources/company'
 
 /**
  * Creates an object with
@@ -23,7 +24,12 @@ function execute (opts) {
       api_key,
     },
   }
-  return merge(body, opts.options)
+  return company.current(body)
+    .catch(() => {
+      if (opts.skipAuthentication) { return }
+      throw new Error('You must supply a valid API key')
+    })
+    .then(() => merge(body, opts.options))
 }
 
 /**

--- a/lib/client/strategies/encryption.js
+++ b/lib/client/strategies/encryption.js
@@ -4,6 +4,7 @@
  * @private
  */
 import { merge } from 'ramda'
+import transactions from '../../resources/transactions'
 
 /**
  * Creates an object with
@@ -23,7 +24,12 @@ function execute (opts) {
       encryption_key,
     },
   }
-  return merge(body, opts.options)
+  return transactions.calculateInstallmentsAmount(body, { amount: 1, interest_rate: 100 })
+    .catch(() => {
+      if (opts.skipAuthentication) { return }
+      throw new Error('You must supply a valid encryption key')
+    })
+    .then(() => merge(body, opts.options))
 }
 
 /**

--- a/lib/client/strategies/index.js
+++ b/lib/client/strategies/index.js
@@ -19,13 +19,7 @@ import encryption from './encryption'
 import login from './login'
 import api from './api'
 
-function isBrowserEnvironment () {
-  if (global === undefined) {
-    return true
-  }
-
-  return false
-}
+const isBrowserEnvironment = typeof global === 'undefined'
 
 function rejectInvalidAuthObject () {
   return Promise.reject(new Error('You must supply a valid authentication object'))
@@ -66,11 +60,12 @@ const strategyBuilder = cond([
  *                    or rejects with an Error.
  */
 function find (options) {
-  if (and(has('api_key', options), isBrowserEnvironment())) {
-    return rejectAPIKeyOnBrowser()
-  }
   if (isNil(options)) {
     return rejectInvalidAuthObject()
+  }
+
+  if (and(has('api_key', options), isBrowserEnvironment)) {
+    return rejectAPIKeyOnBrowser()
   }
 
   return Promise.resolve(strategyBuilder(options))

--- a/lib/client/strategies/index.js
+++ b/lib/client/strategies/index.js
@@ -6,12 +6,34 @@
  * @private
  */
 
-import { and, both, has, cond, propEq, prop, ifElse, equals, not, or, compose, objOf } from 'ramda'
+import {
+  and,
+  both,
+  has,
+  cond,
+  T,
+  isNil,
+} from 'ramda'
 
 import encryption from './encryption'
 import login from './login'
 import api from './api'
-import company from '../../resources/company'
+
+function isBrowserEnvironment () {
+  if (global === undefined) {
+    return true
+  }
+
+  return false
+}
+
+function rejectInvalidAuthObject () {
+  return Promise.reject(new Error('You must supply a valid authentication object'))
+}
+
+function rejectAPIKeyOnBrowser () {
+  return Promise.reject(new Error('You cannot use an api key in the browser!'))
+}
 
 /**
  * Defines the correct authentication
@@ -29,49 +51,8 @@ const strategyBuilder = cond([
   [both(has('email'), has('password')), login.build],
   [has('api_key'), api.build],
   [has('encryption_key'), encryption.build],
+  [T, rejectInvalidAuthObject],
 ])
-
-function isBrowserEnvironment () {
-  if (global === undefined) {
-    return true
-  }
-
-  return false
-}
-
-const buildBody = objOf('body')
-
-function isValidKey (options) {
-  const apiKey = prop('api_key', options)
-  const encryptionKey = prop('encryption_key', options)
-
-  const body = cond([
-    [has('api_key'), () => buildBody({ api_key: apiKey })],
-    [has('encryption_key'), () => buildBody({ encryption_key: encryptionKey })],
-  ])(options)
-
-  return company.current(body)
-}
-
-function rejectInvalidAuthObject () {
-  return Promise.reject(new Error('You must supply a valid authentication object'))
-}
-
-function isValidStrategy (options) {
-  const strategy = strategyBuilder(options)
-
-  const strategyIsNotUndefined = compose(not, equals(undefined))
-
-  return ifElse(
-    strategyIsNotUndefined,
-    () => Promise.resolve(strategy),
-    rejectInvalidAuthObject
-  )(strategy)
-}
-
-function rejectInvalidKey () {
-  return Promise.reject(new Error('You must supply a valid key'))
-}
 
 /**
  * Finds and resolves to a builder
@@ -85,23 +66,14 @@ function rejectInvalidKey () {
  *                    or rejects with an Error.
  */
 function find (options) {
-  const skipAuthentication = propEq('skipAuthentication', true)(options)
-
-  if (skipAuthentication) {
-    return isValidStrategy(options)
+  if (and(has('api_key', options), isBrowserEnvironment())) {
+    return rejectAPIKeyOnBrowser()
+  }
+  if (isNil(options)) {
+    return rejectInvalidAuthObject()
   }
 
-  if (or(has('api_key', options), has('encryption_key', options))) {
-    if (and(has('api_key', options), isBrowserEnvironment())) {
-      return Promise.reject(new Error('You cannot use an api key in the browser!'))
-    }
-
-    return isValidKey(options)
-      .then(() => isValidStrategy(options))
-      .catch(() => rejectInvalidKey())
-  }
-
-  return isValidStrategy(options)
+  return Promise.resolve(strategyBuilder(options))
 }
 
 export default { find }

--- a/lib/resources/index.spec.js
+++ b/lib/resources/index.spec.js
@@ -12,7 +12,7 @@ describe('pagarme.client', () => {
   it('should return an error if an invalid api key is given', () =>
     client.connect({ api_key: 'libjsdonetomorrow' })
       .catch(err =>
-        expect(err.message).toBe('You must supply a valid key'))
+        expect(err.message).toBe('You must supply a valid API key'))
   )
 
   it('should return an error when an invalid auth option is given', () =>
@@ -22,10 +22,25 @@ describe('pagarme.client', () => {
       )
   )
 
-  it('company should have property `object` when a valid api key is given', () =>
+  it('should return an error if an invalid encryption_key is given', () =>
+    client.connect({ encryption_key: 'fwefwe' })
+      .catch(err =>
+        expect(err.message).toBe('You must supply a valid encryption key'))
+  )
+
+  test('when a valid api key is given', () =>
     client.connect({ api_key: process.env.API_KEY })
       .then(cli => cli.company.current())
-      .then(company => expect(company).toHaveProperty('object', 'company')
-    )
+      .then(result => expect(result).toBeTruthy())
+      .catch(err =>
+        expect(err.message).not.toBe('You must supply a valid key'))
+  )
+
+  test('when a valid encryption_key is given', () =>
+    client.connect({ encryption_key: process.env.ENCRYPTION_KEY })
+      .then(cli => cli.transactions.calculateInstallmentsAmount({ amount: 1, interest_rate: 100 }))
+      .then(result => expect(result).toBeTruthy())
+      .catch(err =>
+        expect(err.message).not.toBe('You must supply a valid key'))
   )
 })


### PR DESCRIPTION
This PR fixes the current broken encryption_key validation. It also cleans and moves away validation functions from strategies/index.js to make it more clean and concise.