### PR TITLE
validations: add length validation for cpf/cnpj

### DIFF
--- a/lib/validations/index.test.js
+++ b/lib/validations/index.test.js
@@ -35,8 +35,8 @@ describe('validator', () => {
 
   it('should validate batches of fields', () => {
     const result = validate({
-      cnpj: ['18.727.053/0001-74', '17.727.053/0001-74'],
-      cpf: ['408.855.998-37', '407.855.998-37'],
+      cnpj: ['18.727.053/0001-74', '17.727.053/0001-74', '408.855.998-37', '407.855.998-37'],
+      cpf: ['408.855.998-37', '407.855.998-37', '18.727.053/0001-74', '17.727.053/0001-74'],
       ddd: ['67', 'a9'],
       zipcode: ['05679010', '123456789'],
       phone: ['996220394', 1234],
@@ -56,8 +56,8 @@ describe('validator', () => {
       ],
     })
     expect(result).toMatchObject({
-      cnpj: [true, false],
-      cpf: [true, false],
+      cnpj: [true, false, false, false],
+      cpf: [true, false, false, false],
       ddd: [true, false],
       zipcode: [true, false],
       phone: [true, false],

--- a/lib/validations/validators/cnpj-and-cpf.js
+++ b/lib/validations/validators/cnpj-and-cpf.js
@@ -21,7 +21,6 @@ import {
   F,
   cond,
   allPass,
-  ifElse,
   __,
 } from 'ramda'
 
@@ -111,29 +110,19 @@ const validateDigits = pipe(
 )
 
 // ID -> Boolean
-const isCNPJ = pipe(
-  length,
-  equals(14)
-)
-
-// ID -> Boolean
-const validateId = indexes => cond([
-  [isInvalid, F],
-  [validateDigits(indexes), T],
-  [T, F],
-])
-
-// ID -> Boolean
-const validateCNPJ = validateId([12, 13])
-
-// ID -> Boolean
-const validateCPF = validateId([9, 10])
-
-// RAW_ID -> Boolean
-const validate = pipe(
+const validateId = indexes => pipe(
   toString,
   clean,
-  ifElse(isCNPJ, validateCNPJ, validateCPF)
+  cond([
+    [isInvalid, F],
+    [validateDigits(indexes), T],
+    [T, F],
+  ])
 )
 
-export default validate
+// ID -> Boolean
+export const cnpj = validateId([12, 13])
+
+// ID -> Boolean
+export const cpf = validateId([9, 10])
+

--- a/lib/validations/validators/cnpj-and-cpf.spec.js
+++ b/lib/validations/validators/cnpj-and-cpf.spec.js
@@ -1,31 +1,31 @@
-import id from './cnpj-and-cpf'
+import { cnpj, cpf } from './cnpj-and-cpf'
 
 describe('CNPJ and CPF validator', () => {
   it('should return true when a valid cnpj is given', () => {
-    expect(id('18.727.053/0001-74')).toBe(true)
-    expect(id('18727.053/0001-74')).toBe(true)
-    expect(id('18727.0530001-74')).toBe(true)
-    expect(id('18727053/0001-74')).toBe(true)
-    expect(id('18727053/000174')).toBe(true)
-    expect(id('187270530001-74')).toBe(true)
-    expect(id(18727053000174)).toBe(true)
+    expect(cnpj('18.727.053/0001-74')).toBe(true)
+    expect(cnpj('18727.053/0001-74')).toBe(true)
+    expect(cnpj('18727.0530001-74')).toBe(true)
+    expect(cnpj('18727053/0001-74')).toBe(true)
+    expect(cnpj('18727053/000174')).toBe(true)
+    expect(cnpj('187270530001-74')).toBe(true)
+    expect(cnpj(18727053000174)).toBe(true)
   })
 
   it('should return false when an invalid cnpj is given', () => {
-    expect(id('17.727.053/0001-74')).toBe(false)
-    expect(id('17727.053/0001-74')).toBe(false)
-    expect(id('17727.0530001-74')).toBe(false)
-    expect(id('17727053/0001-74')).toBe(false)
-    expect(id('17727053/000174')).toBe(false)
-    expect(id('177270530001-74')).toBe(false)
-    expect(id(17727053000174)).toBe(false)
+    expect(cnpj('17.727.053/0001-74')).toBe(false)
+    expect(cnpj('17727.053/0001-74')).toBe(false)
+    expect(cnpj('17727.0530001-74')).toBe(false)
+    expect(cnpj('17727053/0001-74')).toBe(false)
+    expect(cnpj('17727053/000174')).toBe(false)
+    expect(cnpj('177270530001-74')).toBe(false)
+    expect(cnpj(17727053000174)).toBe(false)
   })
 
   it('should return true when a valid cpf is given', () => {
-    expect(id('408.855.998-37')).toBe(true)
+    expect(cpf('408.855.998-37')).toBe(true)
   })
 
   it('should return false when an invalid cpf is given', () => {
-    expect(id('407.855.998-37')).toBe(false)
+    expect(cpf('407.855.998-37')).toBe(false)
   })
 })

--- a/lib/validations/validators/index.js
+++ b/lib/validations/validators/index.js
@@ -2,7 +2,7 @@ import {
   anyPass,
 } from 'ramda'
 
-import id from './cnpj-and-cpf'
+import { cnpj, cpf } from './cnpj-and-cpf'
 import numberSize from './numberSize'
 import email from './email'
 import card from './card'
@@ -12,8 +12,8 @@ const phone = anyPass([numberSize(8), numberSize(9)])
 const zipcode = numberSize(8)
 
 export default {
-  cnpj: id,
-  cpf: id,
+  cnpj,
+  cpf,
   ddd,
   email,
   phone,


### PR DESCRIPTION
Previously the CPF and CNPJ validations would wrongly validate
each other. I've added a length validation to stop that from happening.