### PR TITLE
validations: fix card input validation

### DIFF
--- a/lib/validations/index.test.js
+++ b/lib/validations/index.test.js
@@ -27,8 +27,6 @@ describe('validator', () => {
         card_number: true,
         card_cvv: true,
         card_expiration_date: true,
-        card_expiration_month: true,
-        card_expiration_year: true,
       },
     })
   })
@@ -55,6 +53,7 @@ describe('validator', () => {
         },
       ],
     })
+
     expect(result).toMatchObject({
       cnpj: [true, false],
       cpf: [true, false],
@@ -68,8 +67,6 @@ describe('validator', () => {
           card_number: true,
           card_cvv: true,
           card_expiration_date: true,
-          card_expiration_month: true,
-          card_expiration_year: true,
         },
         {
           card_holder_name: false,
@@ -77,10 +74,22 @@ describe('validator', () => {
           card_number: true,
           card_cvv: false,
           card_expiration_date: false,
-          card_expiration_month: true,
-          card_expiration_year: true,
         },
       ],
+    })
+  })
+
+  it('should validate cards with only number', () => {
+    const result = validate({
+      card: {
+        card_number: '348149451448134',
+      },
+    })
+    expect(result).toMatchObject({
+      card: {
+        brand: 'amex',
+        card_number: true
+      }
     })
   })
 

--- a/lib/validations/validators/card/index.js
+++ b/lib/validations/validators/card/index.js
@@ -2,20 +2,42 @@ import {
   __,
   pipe,
   prop,
-  replace,
-  splitEvery,
+  has,
+  not,
+  omit,
 } from 'ramda'
 import getBrand from './getBrand'
 import isValidCvv from './cvv'
 import isValidCardNumber from './isValidCardNumber'
-import isValidExpirationMonth from './isValidExpirationMonth'
-import isValidExpirationYear from './isValidExpirationYear'
 import isValidExpirationDate from './isValidExpirationDate'
 import isValidHolderName from './isValidHolderName'
 
+const validProps = [
+  'card_holder_name',
+  'card_number',
+  'card_expiration_date',
+  'card_cvv',
+]
+
+const missingProps = (card) => {
+  const cardIsMissingProp = pipe(has(__, card), not)
+  return validProps.filter(cardIsMissingProp)
+}
+
+const missingNumber = pipe(
+  has('card_number'),
+  not
+)
+
 const validateCardData = (card) => {
-  const cleanDate = replace(/[^0-9]/g, '', prop('card_expiration_date', card))
-  const [month, year] = splitEvery(2, cleanDate).map(Number)
+  if (missingNumber(card)) {
+    throw new Error('Missing card number')
+  }
+
+  const validateExpirationDate = pipe(
+    prop('card_expiration_date'),
+    isValidExpirationDate
+  )
 
   const validateCardHolderName = pipe(
     prop('card_holder_name'),
@@ -27,11 +49,6 @@ const validateCardData = (card) => {
     isValidCardNumber
   )
 
-  const validateExpirationDate = pipe(
-    prop('card_expiration_date'),
-    isValidExpirationDate
-  )
-
   const brand = getBrand(prop('card_number', card))
 
   const validateCvv = pipe(
@@ -39,15 +56,15 @@ const validateCardData = (card) => {
     isValidCvv(__, brand)
   )
 
-  return {
+  const validated = {
+    brand,
     card_holder_name: validateCardHolderName(card),
     card_number: validateCardNumber(card),
     card_expiration_date: validateExpirationDate(card),
-    card_expiration_month: isValidExpirationMonth(month),
-    card_expiration_year: isValidExpirationYear(year),
-    brand,
-    card_cvv: validateCvv(card),
+    card_cvv: brand ? validateCvv(card) : false,
   }
+
+  return omit(missingProps(card), validated)
 }
 
 export default validateCardData


### PR DESCRIPTION
Proviously the card validator would not check if all card props were
sent. Now an error will be thrown with the missing props information.