### PR TITLE
transactions: fix refund and capture body

### DIFF
--- a/lib/resources/transactions.js
+++ b/lib/resources/transactions.js
@@ -77,7 +77,7 @@ const create = (opts, body) =>
  *                    the request or to an error.
  */
 const capture = (opts, body) =>
-  request.post(opts, routes.transactions.capture(body.id), {})
+  request.post(opts, routes.transactions.capture(body.id), body)
 
 /**
  * `POST /transactions/:id/refund`
@@ -96,7 +96,7 @@ const capture = (opts, body) =>
  *                    the request or to an error.
  */
 const refund = (opts, body) =>
-  request.post(opts, routes.transactions.refund(body.id), {})
+  request.post(opts, routes.transactions.refund(body.id), body)
 
 /**
  * `POST /transactions/:id/collect_payment`

--- a/lib/resources/transactions.spec.js
+++ b/lib/resources/transactions.spec.js
@@ -8,11 +8,12 @@ test('client.transaction.capture', () =>
     connect: {
       api_key: 'abc123',
     },
-    subject: client => client.transactions.capture({ id: 1234 }),
+    subject: client => client.transactions.capture({ id: 1234, amount: 1243 }),
     method: 'POST',
     url: '/transactions/1234/capture',
     body: {
       api_key: 'abc123',
+      amount: 1243,
     },
   })
 )
@@ -97,17 +98,17 @@ test('client.transactions.all', () =>
   }))
 )
 
-
 test('client.transactions.refund', () =>
   runTest({
     connect: {
       api_key: 'abc123',
     },
-    subject: client => client.transactions.refund({ id: 1234 }),
+    subject: client => client.transactions.refund({ id: 1234, amount: 123 }),
     method: 'POST',
     url: '/transactions/1234/refund',
     body: {
       api_key: 'abc123',
+      amount: 123,
     },
   })
 )


### PR DESCRIPTION
Both `refund` and `capture` were not passing the `body` forward.