### PR TITLE
strategies: add better error handling when offline

### DIFF
--- a/lib/client/strategies/api.js
+++ b/lib/client/strategies/api.js
@@ -6,6 +6,7 @@
 import { merge } from 'ramda'
 import company from '../../resources/company'
 
+
 /**
  * Creates an object with
  * the `api_key` from
@@ -18,21 +19,27 @@ import company from '../../resources/company'
  * @private
  */
 function execute (opts) {
-  const { api_key } = opts
+  const { api_key, options } = opts
   const body = {
     body: {
       api_key,
     },
   }
+  if (options && options.baseURL) {
+    body.baseURL = options.baseURL
+  }
   return company.current(body)
-    .catch(() => {
+    .catch((error) => {
       if (opts.skipAuthentication) { return }
-      throw new Error('You must supply a valid API key')
+      if (error.name === 'ApiError') {
+        throw new Error('You must supply a valid API key')
+      }
+      console.warn(`Warning: Could not verify key. Pagar.me may be offline ${error.name}`)
     })
     .then(() => merge(body, opts.options))
-    .then(options => ({
+    .then(requestOpts => ({
       authentication: { api_key },
-      options,
+      options: requestOpts,
     }))
 }
 

--- a/lib/client/strategies/encryption.js
+++ b/lib/client/strategies/encryption.js
@@ -18,21 +18,27 @@ import transactions from '../../resources/transactions'
  * @private
  */
 function execute (opts) {
-  const { encryption_key } = opts
+  const { encryption_key, options } = opts
   const body = {
     body: {
       encryption_key,
     },
   }
+  if (options && options.baseURL) {
+    body.baseURL = options.baseURL
+  }
   return transactions.calculateInstallmentsAmount(body, { amount: 1, interest_rate: 100 })
-    .catch(() => {
+    .catch((error) => {
       if (opts.skipAuthentication) { return }
-      throw new Error('You must supply a valid encryption key')
+      if (error.name === 'ApiError') {
+        throw new Error('You must supply a valid encryption key')
+      }
+      console.warn(`Warning: Could not verify key. Pagar.me may be offline ${error.name}`)
     })
     .then(() => merge(body, opts.options))
-    .then(options => ({
+    .then(requestOpts => ({
       authentication: { encryption_key },
-      options,
+      options: requestOpts,
     }))
 }
 

--- a/lib/resources/index.spec.js
+++ b/lib/resources/index.spec.js
@@ -44,4 +44,22 @@ describe('pagarme.client', () => {
       .then(result => expect(result).toBeTruthy())
       .catch(err =>
         expect(err.message).not.toBe('You must supply a valid key')))
+
+  test('when Pagarme is offline and API key is used', () =>
+    pagarme.client.connect({
+      api_key: 'nwdu91jd9',
+      options: {
+        baseURL: 'http://a-big-non-existent-website-from-interwebs.nope',
+      },
+    })
+      .then(tap(client => expect(client.authentication.api_key).toBe('nwdu91jd9'))))
+
+  test('when Pagarme is offline and encryption key is used', () =>
+    pagarme.client.connect({
+      encryption_key: 'nwdu91jd9',
+      options: {
+        baseURL: 'http://a-big-non-existent-website-from-interwebs.nope',
+      },
+    })
+      .then(tap(client => expect(client.authentication.encryption_key).toBe('nwdu91jd9'))))
 })


### PR DESCRIPTION
Adds a warning when client.connect can't communicate with pagarme's
server. Now the client will only log a warning instead of throwing
an error if it fails to send the key verification request. It will
still give an error if the request is successfull and the key is invalid