### PR TITLE
tests: fix e2e tests

### DIFF
--- a/lib/resources/index.spec.js
+++ b/lib/resources/index.spec.js
@@ -29,19 +29,16 @@ describe('pagarme.client', () => {
     pagarme.client.connect({ api_key: process.env.API_KEY })
       .then(tap(client => expect(client.authentication.api_key).toBe(process.env.API_KEY)))
       .then(client => client.company.current())
-      .then(result => expect(result).toBeTruthy())
-      .catch(err =>
-        expect(err.message).not.toBe('You must supply a valid key')))
+      .then(result => expect(result).toBeTruthy()))
 
   test('when a valid encryption_key is given', () =>
     pagarme.client.connect({ encryption_key: process.env.ENCRYPTION_KEY })
-      .then(tap(client => expect(client.authentication.ecryption_key)
+      .then(tap(client => expect(client.authentication.encryption_key)
         .toBe(process.env.ENCRYPTION_KEY)))
       .then(client => client.transactions.calculateInstallmentsAmount({
         amount: 1,
         interest_rate: 100,
       }))
-      .then(result => expect(result).toBeTruthy())
-      .catch(err =>
-        expect(err.message).not.toBe('You must supply a valid key')))
+      .then(result => expect(result).toBeTruthy()))
 })
+


### PR DESCRIPTION
The e2e tests that tested pagarme.connect were passing when they shouldn't.
This was caused by a PR that changed the error messages when connect failed.
If we intend to change these messages again we should make a new error type
to avoid having to fix this again.