### PR TITLE
resources: add `all` alias missing docs

### DIFF
--- a/lib/resources/invites.js
+++ b/lib/resources/invites.js
@@ -37,6 +37,14 @@ const find = (opts, body = {}) =>
   ])(body)
 
 /**
+ * `GET /invites`
+ * Makes a request to /invites to get all invites.
+ *
+*/
+const all = opts =>
+  findAll(opts)
+
+/**
  * `POST /invites`
  * Creates an invite from the given payload.
  *
@@ -73,6 +81,7 @@ const destroy = (opts, body) =>
 
 export default {
   find,
+  all,
   create,
   destroy,
 }

--- a/lib/resources/recipients.js
+++ b/lib/resources/recipients.js
@@ -43,6 +43,19 @@ const find = (opts, body) =>
     [T, findAll(opts)],
   ])(body)
 
+/**
+ * `GET /recipients`
+ * Makes a request to /recipients to get all recipients.
+ *
+ * @param {Object} opts An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+ *
+ * @param {Number} [body.count] Pagination option for recipient list.
+ *                              Number of recipient in a page
+ * @param {Number} [body.page] Pagination option for recipient list.
+ *                             The page index.
+*/
 const all = (opts, body) =>
   findAll(opts, body)
 

--- a/lib/resources/subscriptions.js
+++ b/lib/resources/subscriptions.js
@@ -44,21 +44,19 @@ const find = (opts, body) =>
 
 /**
  * `GET /subscriptions`
- * Makes a request to /subscriptions
+ * Makes a request to /subscriptions to get all subscriptions.
  *
  * @param {Object} opts An options params which
  *                      is usually already bound
  *                      by `connect` functions.
  *
- * @param {Object} body The payload for the request.
- * {@link https://pagarme.readme.io/v1/reference#retornando-assinaturas|API Reference for this payload}
  * @param {Number} [body.count] Pagination option to get a list of subscriptions.
  *                              Number of subscriptions in a page
  * @param {Number} [body.page] Pagination option for a list of subscriptions.
  *                             The page index.
 */
-const all = (opts, pagination) =>
-  findAll(opts, pagination)
+const all = (opts, body) =>
+  findAll(opts, body)
 
 /**
  * `POST /subscriptions`

--- a/lib/resources/transactions.js
+++ b/lib/resources/transactions.js
@@ -43,6 +43,19 @@ const find = (opts, body) =>
     [T, findAll(opts)],
   ])(body)
 
+/**
+ * `GET /transactions`
+ * Makes a request to /transactions to get all transactions.
+ *
+ * @param {Object} opts An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+ *
+ * @param {Number} [body.count] Pagination option for recipient list.
+ *                              Number of recipient in a page
+ * @param {Number} [body.page] Pagination option for recipient list.
+ *                             The page index.
+*/
 const all = (opts, body) =>
   findAll(opts, body)
 

--- a/lib/resources/transfers.js
+++ b/lib/resources/transfers.js
@@ -44,7 +44,7 @@ const find = (opts, body) =>
 
 /**
  * `GET /transfers`
- * Makes a request to /transfers
+ * Makes a request to /transfers to get all transfers.
  *
  * @param {Object} opts An options params which
  *                      is usually already bound

--- a/lib/resources/user.js
+++ b/lib/resources/user.js
@@ -96,16 +96,13 @@ const create = (opts, body) =>
  *                      is usually already bound
  *                      by `connect` functions.
  *
- * @param {Object} body The payload for the request.
  * @param {Number} [body.count] Pagination option to get a list of users.
  *                              Number of users in a page
  * @param {Number} [body.page] Pagination option for a list of users.
  *                             The page index.
- * @returns {Promise} Resolves to the result of
- *                    the request or to an error.
 */
-const all = (opts, pagination) =>
-  findAll(opts, pagination)
+const all = (opts, body) =>
+  findAll(opts, body)
 
 /**
  * `DELETE /users/:id`


### PR DESCRIPTION
Some of the endpoints that had `all` alias were missing docs for it.
This adds the missing docs.