### PR TITLE
transactions: fix `update` body link doc

### DIFF
--- a/lib/resources/transactions.js
+++ b/lib/resources/transactions.js
@@ -144,7 +144,7 @@ const cardHashKey = opts =>
  *                      by `connect` functions.
  *
  * @param {Object} body The payload for the request.
- * {@link https://pagarme.readme.io/reference#calculando-pagamentos-parcelados|API Reference for this payload}
+ *
  * @param {Number} body.id The transaction ID
  * @param {Number} body.status The transaction status
  * @returns {Promise} A promise that resolves to


### PR DESCRIPTION
This link doesn't exist in the new API docs. We have a lot of endpoints
that are missing in the new API docs so this only deletes the wrong
link. We need to address the missing parts but that's a different issue.