### PR TITLE
Use api_key from temporary companies 

### DIFF
--- a/lib/resources/index.spec.js
+++ b/lib/resources/index.spec.js
@@ -1,5 +1,13 @@
 import { tap } from 'ramda'
 import pagarme from '../..'
+import fetch from 'isomorphic-fetch'
+
+const getTemporaryCompany = () => {
+  return fetch('https://api.pagar.me/1/companies/temporary', {
+    method: 'post'
+  })
+  .then((response) => response.json())
+}
 
 /*
  *
@@ -25,23 +33,33 @@ describe('pagarme.client', () => {
       .catch(err =>
         expect(err.message).toBe('You must supply a valid encryption key')))
 
-  test('when a valid api key is given', () =>
-    pagarme.client.connect({ api_key: process.env.API_KEY })
-      .then(tap(client => expect(client.authentication.api_key).toBe(process.env.API_KEY)))
-      .then(client => client.company.current())
-      .then(result => expect(result).toBeTruthy()))
+    test('when a valid api key is given', () => {
+      getTemporaryCompany()
+        .then((company) => {
+          return pagarme.client.connect({ api_key: company.api_key.test })
+            .then(client => client.company.current())
+            .then(result => expect(!!result).toBeTruthy())
+        })
+    })
 
-  test('when a valid encryption_key is given', () =>
-    pagarme.client.connect({ encryption_key: process.env.ENCRYPTION_KEY })
-      .then(tap(client => expect(client.authentication.encryption_key)
-        .toBe(process.env.ENCRYPTION_KEY)))
-      .then(client => client.transactions.calculateInstallmentsAmount({
-        amount: 1,
-        interest_rate: 100,
-      }))
-      .then(result => expect(result).toBeTruthy())
-      .catch(err =>
-        expect(err.message).not.toBe('You must supply a valid key')))
+  test('when a valid encryption_key is given', () => {
+    getTemporaryCompany()
+      .then((company) => {
+        const ek = company.encryption_key.test
+
+        return pagarme.client.connect({ encryption_key: ek })
+        .then(tap(client => expect(client.authentication.encryption_key)
+        .toBe(ek)))
+        .then(client => client.transactions.calculateInstallmentsAmount({
+          amount: 1,
+          interest_rate: 100,
+        }))
+        .then(result => expect(result).toBeTruthy())
+        .catch(err =>
+          expect(err.message).not.toBe('You must supply a valid key'))
+
+      })
+  })
 
   test('when Pagarme is offline and API key is used', () =>
     pagarme.client.connect({
@@ -61,4 +79,3 @@ describe('pagarme.client', () => {
     })
       .then(tap(client => expect(client.authentication.encryption_key).toBe('nwdu91jd9'))))
 })
-


### PR DESCRIPTION
It fixes the usage of process.env.API_KEY