### PR TITLE
Remove payload validation

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -13,7 +13,6 @@ import {
   merge,
   length,
   keys,
-  not,
 } from 'ramda'
 import qs from 'qs'
 import routes from './routes'
@@ -48,12 +47,6 @@ function buildRequestParams (method, endpoint, options, data) {
     options.body || {},
     data || {}
   )
-
-  const isPayloadValid = length(keys(payload)) > 0
-
-  if (not(isPayloadValid)) {
-    throw new Error('Invalid request payload')
-  }
 
   const queries = options.qs || {}
 


### PR DESCRIPTION
As the SDK is agnostic with the payload's content, then it sounds reasonable to not have a payload validation - even the simplest.