### PR TITLE
docs: fix client connection example

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -48,10 +48,10 @@ function bindClientOptions ({ options, authentication }) {
  *
  * @example
  * // API Key Authentication
- * pagarme.client.connect({ apiKey: 'ak_test_y7jk294ynbzf93' })
+ * pagarme.client.connect({ api_key: 'ak_test_y7jk294ynbzf93' })
  *
  * // Encryption Key Authentication
- * pagarme.client.connect({ encryptionKey: 'ek_test_y7jk294ynbzf93' })
+ * pagarme.client.connect({ encryption_key: 'ek_test_y7jk294ynbzf93' })
  *
  * // Login Authentication
  * pagarme.client.connect({ email: 'user@email.com', password: '123456' })


### PR DESCRIPTION
The connection example is using lower camel case to pass the keys, which in a real implementation won't work.

Resolves: #75