### PR TITLE
validations: fix some unexpected validations errors

### DIFF
--- a/lib/validations/index.spec.js
+++ b/lib/validations/index.spec.js
@@ -31,6 +31,34 @@ describe('validator', () => {
     })
   })
 
+  it('should validate card number as int', () => {
+    const result = validate({
+      card: {
+        card_number: 5545497548400992
+      }
+    })
+
+    expect(result).toMatchObject({
+      card: {
+        card_number: true
+      }
+    })
+  })
+
+  it('should validate unknown brand when none were found', () => {
+    const result = validate({
+      card: {
+        card_number: '1'
+      }
+    })
+
+    expect(result).toMatchObject({
+      card: {
+        brand: 'unknown'
+      }
+    })
+  })
+
   it('should validate batches of fields', () => {
     const result = validate({
       cnpj: ['18.727.053/0001-74', '17.727.053/0001-74', '408.855.998-37', '407.855.998-37'],

--- a/lib/validations/validators/card/getBrand.js
+++ b/lib/validations/validators/card/getBrand.js
@@ -1,4 +1,6 @@
 import {
+  defaultTo,
+  toString,
   always,
   replace,
   pipe,
@@ -34,10 +36,12 @@ const getBrand = pipe(
   mapBins,
   toPairs,
   find(pair => last(pair) === true),
-  head
+  defaultTo(['unknown']),
+  head,
 )
 
 export default pipe(
+  toString,
   clean,
   ifElse(isEmpty, always('unknown'), getBrand)
 )


### PR DESCRIPTION
This fix some unexpected validations errors that was happening due to
variations in card number, like when card number was type number instead
of string and when card number was one-digit number and  didn't match
any brand.

 - Fix card number validations to receive card_number typed as a number
   instead of string

 - Fix brand validation to be unknown when card number is one-digit
   and don't match any brand

Resolves: #78