### PR TITLE
npmignore: add babelrc to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,3 @@
 test/
 webpack.config.js
-
+.babelrc


### PR DESCRIPTION
To avoid problems with projects using babel 6.
#82