### PR TITLE
Feature/add GitHub files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [dashboard@pagar.me](mailto:dashboard@pagar.me). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [dashboard@pagar.me](mailto:dashboard@pagar.me). All
+reported by contacting the project team at [suporte@pagar.me](mailto:suporte@pagar.me). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -49,6 +49,12 @@ Fork the repo and clone it in your machine: `git clone git@github.com:YOUR_USERN
 yarn
 ```
 
+or
+
+```sh
+npm i
+```
+
 #### Make sure the tests are passing
 
 > To run tests, you need to export API_KEY environment variable with your API key. When submitting a PR, Travis will already have it exported.
@@ -57,10 +63,22 @@ yarn
 yarn test
 ```
 
+or
+
+```sh
+npm run test
+```
+
 #### Build the project
 
 ```sh
 yarn start
+```
+
+or
+
+```sh
+npm start
 ```
 
 - Node.js build is produced inside the dist directory.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing
+
+Thank's for you interest in contributing! :tada::+1:
+
+This are the common guidelines to contribute to `pagarme-js`. Please ensure the following guidelines are being followed by you and any other contributor.
+
+## Code of conduct
+
+This project and everyone participating in it is governed by the [Pagar.me Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [dashboard@pagar.me](mailto:dashboard@pagar.me).
+
+## How can I contribute?
+
+Help us maintaining this project by reporting bugs, improving our codebase, creating more documentation and submiting new pull requests for features you would like to see in this project.
+
+## Guidelines :rotating_light:
+
+### Speak English
+
+English is an universal language used across the world and in the vast majority of tools and coding vocabulary.
+
+### Write good commit messages
+
+We follow the [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide). Every commit/branch/pull_request must follow its guidelines.
+
+### How to report a bug
+
+If you find a security vulnerability, do NOT open an issue. Email [dashboard@pagar.me](mailto:dashboard@pagar.me) instead.
+
+When reporting a bug make sure to include:
+- The project version you are running
+- Your OS
+- Node.js version
+- Steps to reproduce
+- Current and expected behavior
+
+### Code style
+
+Make sure that when writing code you are following [Pagarme's style guide](https://github.com/pagarme/javascript-style-guide)
+
+## Contributing
+
+> We provide source maps to ease debugging. Use them whenever possible when providing stack traces as it will make digging onto the issue easier.
+
+Fork the repo and clone it in your machine: `git clone git@github.com:YOUR_USERNAME/pagarme-js.git`
+
+#### Install the dependencies
+
+```sh
+yarn
+```
+
+#### Make sure the tests are passing
+
+> To run tests, you need to export API_KEY environment variable with your API key. When submitting a PR, Travis will already have it exported.
+
+```sh
+yarn test
+```
+
+#### Build the project
+
+```sh
+yarn start
+```
+
+- Node.js build is produced inside the dist directory.
+- Browser build is produced inside the browser directory.
+
+#### Opening your PR
+
+- Make sure the tests still passes (and that you added new ones if needed)
+- Fill the PR template when opening it trough GitHub
+- Include screenshots and animated GIFs whenever possible.
+
+If in doubt, just send us a PR or open an issue to discussion! We're always happy for receiving contributions!

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Description
+<!--
+Write a good description for your issue. Give as many details you can to help us with the investigation and developing :)
+If relevant, attach screenshots/animated GIFs, and how to reproduce
+-->
+
+## My Setup
+- Operating System:
+- Project Version:
+
+<!-- Answer questions by putting x in box, e.g. [x] -->
+- [ ] I have tested with the latest version
+- [ ] I can simulate the issue easily
+
+### Current Behavior
+<!-- What actually happens? -->
+
+### Expected Behavior
+<!-- What do you think should happen? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,5 @@ Things to cite on the PR description:
 1. My changes are well covered by **tests** and **logs**
 1. I've updated the project docs (if needed)
 1. I fell safe about this implementation
-1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends
 
 In a good pull request, everything above is true :relaxed:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Description
+
+Write a brief and explicative description of your pull request.
+
+<!--
+Things to cite on the PR description:
+
+- Why is the PR needed
+- What the PR does
+- What are possible side effects
+- Additional information (related github issues, links, etc)
+
+  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
+-->
+
+## Your checklist for this pull request
+
+:rotating_light: Please review this items for a good pull request. :four_leaf_clover:
+
+1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
+1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
+1. My changes are well covered by **tests** and **logs**
+1. I've updated the project docs (if needed)
+1. I fell safe about this implementation
+1. I feel comfortable with the code I wrote, and I'm not ashamed to show it to my friends
+
+In a good pull request, everything above is true :relaxed:


### PR DESCRIPTION
Closes #69 and closes #70 

I tried to keep the templates consistent between what I saw in other Pagarme's projects, more details can be found in the commit messages! 

Some other considerations:
- On contribution guide I wrote the start commands using `yarn` instead of `npm` as there's already a _yarn.lock_ in this project, if this is not what you recommend, I can change it
- The email for reporting abusive behavior and security flaws was dashboard@pagar.me, as it is the only one I know for reaching you guys (besides _code@pagar.me_, but I think this one is for sending resumes, right?) 
