### PR TITLE
cpf-validation: replace blacklist for regex

### DIFF
--- a/lib/validations/validate/cnpjAndCpf.js
+++ b/lib/validations/validate/cnpjAndCpf.js
@@ -6,7 +6,6 @@ import {
   apply,
   both,
   complement,
-  contains,
   equals,
   either,
   isEmpty,
@@ -29,29 +28,7 @@ import {
 // RAW_ID = ID before special characters cleanup
 // DIGIT = Number from 0 to 9
 
-
-const blackList = [
-  '00000000000000',
-  '11111111111111',
-  '22222222222222',
-  '33333333333333',
-  '44444444444444',
-  '55555555555555',
-  '66666666666666',
-  '77777777777777',
-  '88888888888888',
-  '99999999999999',
-  '00000000000',
-  '11111111111',
-  '22222222222',
-  '33333333333',
-  '44444444444',
-  '55555555555',
-  '66666666666',
-  '77777777777',
-  '88888888888',
-  '99999999999',
-]
+const repeatedNumberRegex = /^(.)\1+$/
 
 const mapIndexed = addIndex(map)
 
@@ -67,8 +44,11 @@ const weigthMasks = {
 // String -> String
 const clean = replace(/[^\d]+/g, '')
 
+// [String] -> ID -> Boolean
+const hasOnlyOneNumber = subject => repeatedNumberRegex.test(subject)
+
 // ID -> Boolean
-const hasValidForm = complement(either(isEmpty, contains(__, blackList)))
+const hasValidForm = complement(either(isEmpty, hasOnlyOneNumber))
 
 // [Number] -> ID -> DIGIT
 const generateDigitWithMask = mask => pipe(

--- a/lib/validations/validate/cnpjAndCpf.spec.js
+++ b/lib/validations/validate/cnpjAndCpf.spec.js
@@ -27,5 +27,7 @@ describe('CNPJ and CPF validator', () => {
 
   it('should return false when an invalid cpf is given', () => {
     expect(cpf('407.855.998-37')).toBe(false)
+    expect(cpf('000.000.000-00')).toBe(false)
+    expect(cpf('00000000000')).toBe(false)
   })
 })


### PR DESCRIPTION
instead of using an array of blacklisted cpf's uses a regex instead

closes #60 

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
