### PR TITLE
Add Chargebacks route

### DIFF
--- a/lib/resources/chargebacks.js
+++ b/lib/resources/chargebacks.js
@@ -1,0 +1,29 @@
+/**
+ * @name Chargebacks
+ * @description This module exposes functions
+ *              related to the `/chargebacks` path.
+ *
+ * @module chargebacks
+ **/
+
+import routes from '../routes'
+import request from '../request'
+
+/**
+ * `GET /chargebacks`
+ * Finds chargebacks
+ *
+ * @param {Object} opts An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+ * @param {Object} query The query object to be sent.
+ * {@link https://pagarme.readme.io/v1/reference#retornando-chargebacks|API Reference for this payload}
+ * @returns {Promise} Resolves to the result of
+ *                    the request or to an error.
+ */
+const find = (opts, query) =>
+  request.get(opts, routes.chargebacks, query)
+
+export default {
+  find,
+}

--- a/lib/resources/chargebacks.spec.js
+++ b/lib/resources/chargebacks.spec.js
@@ -1,0 +1,17 @@
+import runTest from '../../test/runTest'
+
+test('client.chargebacks', () =>
+  runTest({
+    connect: {
+      api_key: 'abc123',
+    },
+    subject: client => client.chargebacks.find({
+      transaction_id: '123',
+    }),
+    method: 'GET',
+    url: '/chargebacks',
+    body: {
+      api_key: 'abc123',
+    },
+  })
+)

--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -3,6 +3,7 @@ import payables from './payables'
 import search from './search'
 import user from './user'
 import company from './company'
+import chargebacks from './chargebacks'
 import session from './session'
 import invites from './invites'
 import splitRules from './splitRules'
@@ -27,6 +28,7 @@ import zipcodes from './zipcodes'
 
 export default {
   company,
+  chargebacks,
   search,
   session,
   transactions,

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -104,6 +104,8 @@ const subscriptions = {
   transactions: id => `/subscriptions/${id}/transactions`,
 }
 
+const chargebacks = '/chargebacks'
+
 const cards = {
   base: '/cards',
   details: id => `/cards/${id}`,
@@ -166,6 +168,7 @@ const zipcodes = {
 
 export default {
   acquirers,
+  chargebacks,
   acquirersConfigurations,
   antifraudAnalyses,
   balance,


### PR DESCRIPTION
This adds the missing `GET /chargebacks` route.