### PR TITLE
Add status route

### DIFF
--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -26,6 +26,7 @@ import postbacks from './postbacks'
 import security from './security'
 import customers from './customers'
 import zipcodes from './zipcodes'
+import status from './status'
 
 export default {
   company,
@@ -56,4 +57,5 @@ export default {
   security,
   customers,
   zipcodes,
+  status,
 }

--- a/lib/resources/status.js
+++ b/lib/resources/status.js
@@ -1,0 +1,22 @@
+/**
+ * @name Status
+ * @description This module exposes functions
+ *              related to the `/status` route.
+ *
+ * @module status
+ **/
+
+import routes from '../routes'
+import request from '../request'
+
+/**
+ * `POST /status`
+ * Returns the service status and environment.
+ *
+ * @returns {Promise} Resolves to the result of
+ *                    the request or to an error.
+ */
+const status = opts => request.get(opts, routes.status)
+
+export default status
+

--- a/lib/resources/status.spec.js
+++ b/lib/resources/status.spec.js
@@ -1,0 +1,15 @@
+import runTest from '../../test/runTest'
+
+test('client.status', () =>
+  runTest({
+    connect: {
+      api_key: 'abc123',
+    },
+    method: 'GET',
+    url: '/status',
+    body: {
+      api_key: 'abc123',
+    },
+    subject: client => client.status(),
+  })
+)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -170,6 +170,8 @@ const zipcodes = {
   details: zipcode => `/zipcodes/${zipcode}`,
 }
 
+const status = '/status'
+
 export default {
   acquirers,
   chargebacks,
@@ -199,4 +201,5 @@ export default {
   user,
   customers,
   zipcodes,
+  status,
 }


### PR DESCRIPTION
This adds `/status` route to library, allowing users to find the environment
and check for service status too.