### PR TITLE
Allow creating a client with live environment when using login strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,13 @@ pagarme.min.js.map
 pagarme.js
 pagarme.js.map
 
+### Vim/Neovim ###
+
+*.swm
+*.swn
+*.swo
+*.swp
+
 ### Node ###
 # Logs
 logs

--- a/lib/client/strategies/login.js
+++ b/lib/client/strategies/login.js
@@ -3,30 +3,36 @@
  * @memberof strategies
  * @private
  */
-import { merge, pick, objOf, pipe } from 'ramda'
+import { merge } from 'ramda'
 
 import session from '../../resources/session'
 
-const buildSessionAuth = pipe(
-  pick(['session_id']),
-  objOf('body')
-)
+const buildSessionAuth = ({ session_id }, headers) => ({
+  body: { session_id },
+  headers,
+})
 
 /**
  * Creates a session in the server
  * and returns a Promise with the
  * pertinent object.
+ * Allows setting the environment
+ * to live passing `environment: "live"`.
  *
- * @param {any} { email, password }
+ * @param {any} { email, password, environment }
  * @returns {Promise} Resolves to an object
  *                    containing a body with
  *                    the desired `session_id`
  * @private
  */
-function execute ({ email, password }) {
-  return session.create({}, email, password)
+function execute ({ email, password, environment }) {
+  const headers = environment === 'live'
+    ? { 'X-Live': 1 }
+    : {}
+
+  return session.create({ headers }, email, password)
     .then(sessionInfo => ({
-      options: buildSessionAuth(sessionInfo),
+      options: buildSessionAuth(sessionInfo, headers),
       authentication: sessionInfo,
     }))
 }


### PR DESCRIPTION
This allows specifying `environment: 'live'` on login authentication
strategy, which sets the `X-Live: 1` header in all requests sent by
the client, allowing the client to issue requests to live environment.