### PR TITLE
Add status to error.response

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -98,13 +98,16 @@ function handleError (response) {
   if (response.status === 500) {
     return Promise.reject(
       new ApiError({
+        status: 500,
         errors: [{ message: 'Pagar.me server error' }],
       })
     )
   }
 
   return response.json()
-    .then(body => Promise.reject(new ApiError(body)))
+    .then(body => Promise.reject(
+      new ApiError(merge(body, { status: response.status }))
+    ))
 }
 
 /**


### PR DESCRIPTION
Adds `error.response.status` to get error response status code.
This is needed as we don't have good error keys on body.