### PR TITLE
client: add the method to connect synchronously

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -63,6 +63,29 @@ function connect (authentication) {
     .then(bindClientOptions)
 }
 
-const client = merge({ connect }, resources)
+/**
+ * Sync returns a version of client with
+ * authentication data binded to the
+ * resource requests.
+ *
+ * @example
+ * // API Key Authentication
+ * const client = pagarme.client.connectSync({ api_key: 'ak_test_y7jk294ynbzf93' })
+ *
+ * // Encryption Key Authentication
+ * const client = pagarme.client.connectSync({ encryption_key: 'ek_test_y7jk294ynbzf93' })
+ *
+ * // Login Authentication
+ * const client = pagarme.client.connectSync({ email: 'user@email.com', password: '123456' })
+ *
+ * @param {Object} authentication
+ * @returns A client with authentication data binded
+ */
+function connectSync (authentication) {
+  const strategy = strategies.findSync(authentication)
+  return bindClientOptions(strategy.execute())
+}
+
+const client = merge({ connect, connectSync }, resources)
 
 export default client

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -64,9 +64,14 @@ function connect (authentication) {
 }
 
 /**
- * Sync returns a version of client with
+ * Returns a version of client with
  * authentication data binded to the
- * resource requests.
+ * resource requests synchronously.
+ * Be aware that connecting synchronously
+ * will skip the credentials validation
+ * step and that by that lead to
+ * postponed credential errors when
+ * invoking real actions.
  *
  * @example
  * // API Key Authentication

--- a/lib/client/strategies/api.js
+++ b/lib/client/strategies/api.js
@@ -8,7 +8,7 @@ import company from '../../resources/company'
 
 
 /**
- * Creates an object with
+ * Resolves an object with
  * the `api_key` from
  * the supplied `options` param
  *
@@ -44,9 +44,10 @@ function execute (opts) {
 }
 
 /**
- * Creates an object with
+ * Returns an object with
  * the `api_key` from
  * the supplied `options` param
+ * synchronously
  *
  * @param {any} options
  * @returns {Object} Return an object containing

--- a/lib/client/strategies/api.js
+++ b/lib/client/strategies/api.js
@@ -13,9 +13,9 @@ import company from '../../resources/company'
  * the supplied `options` param
  *
  * @param {any} options
- * @returns {Object} an object containing
- *                   a body property with
- *                   the desired `api_key
+ * @returns {Promise} Resolve to an object
+ *                    containing a body property
+ *                    with the desired `api_key
  * @private
  */
 function execute (opts) {
@@ -44,6 +44,46 @@ function execute (opts) {
 }
 
 /**
+ * Creates an object with
+ * the `api_key` from
+ * the supplied `options` param
+ *
+ * @param {any} options
+ * @returns {Object} Return an object containing
+ *                   a body property with
+ *                   the desired `api_key
+ * @private
+ */
+function executeSync (opts) {
+  const { api_key, options } = opts
+  const body = {
+    body: {
+      api_key,
+    },
+  }
+  if (options && options.baseURL) {
+    body.baseURL = options.baseURL
+  }
+  return {
+    authentication: { api_key },
+    options: merge(body, opts.options),
+  }
+}
+
+/**
+ * Returns the supplied parameter with
+ * the `execute` function added to it.
+ *
+ * @param {any} options
+ * @returns {Promise} Resolve to `options` parameter
+ *                   with `execute` add to it
+ * @private
+ */
+function build (options) {
+  return merge(options, { execute: execute.bind(null, options) })
+}
+
+/**
  * Returns the supplied parameter with
  * the `execute` function added to it.
  *
@@ -52,10 +92,11 @@ function execute (opts) {
  *                   with `execute` add to it
  * @private
  */
-function build (options) {
-  return merge(options, { execute: execute.bind(null, options) })
+function buildSync (options) {
+  return merge(options, { execute: executeSync.bind(null, options) })
 }
 
 export default {
   build,
+  buildSync,
 }

--- a/lib/client/strategies/encryption.js
+++ b/lib/client/strategies/encryption.js
@@ -37,9 +37,10 @@ function execute (opts) {
 }
 
 /**
- * Creates an object with
+ * Returns an object with
  * the `encryption_key` from
  * the supplied `options` param
+ * synchronously.
  *
  * @param {any} options
  * @returns {Object} an object containing

--- a/lib/client/strategies/encryption.js
+++ b/lib/client/strategies/encryption.js
@@ -8,12 +8,12 @@ import { merge } from 'ramda'
 import transactions from '../../resources/transactions'
 
 /**
- * Creates an object with
+ * Resolves to an object with
  * the `encryption_key` from
  * the supplied `options` param
  *
  * @param {any} options
- * @returns {Object} an object containing
+ * @returns {Promise} an object containing
  *                   a body property with
  *                   the desired `encryption_key`
  * @private
@@ -37,6 +37,46 @@ function execute (opts) {
 }
 
 /**
+ * Creates an object with
+ * the `encryption_key` from
+ * the supplied `options` param
+ *
+ * @param {any} options
+ * @returns {Object} an object containing
+ *                   a body property with
+ *                   the desired `encryption_key`
+ * @private
+ */
+function executeSync (opts) {
+  const { encryption_key, options } = opts
+  const body = {
+    body: {
+      encryption_key,
+    },
+  }
+  if (options && options.baseURL) {
+    body.baseURL = options.baseURL
+  }
+  return {
+    authentication: { encryption_key },
+    options: merge(body, opts.options),
+  }
+}
+
+/**
+ * Resolves the supplied parameter with
+ * the `execute` function added to it.
+ *
+ * @param {any} options
+ * @returns {Promise} The `options` parameter
+ *                   with `execute` add to it
+ * @private
+ */
+function build (options) {
+  return merge(options, { execute: execute.bind(null, options) })
+}
+
+/**
  * Returns the supplied parameter with
  * the `execute` function added to it.
  *
@@ -45,10 +85,11 @@ function execute (opts) {
  *                   with `execute` add to it
  * @private
  */
-function build (options) {
-  return merge(options, { execute: execute.bind(null, options) })
+function buildSync (options) {
+  return merge(options, { execute: executeSync.bind(null, options) })
 }
 
 export default {
   build,
+  buildSync,
 }

--- a/lib/client/strategies/index.js
+++ b/lib/client/strategies/index.js
@@ -26,14 +26,22 @@ function rejectInvalidAuthObject () {
   return Promise.reject(new Error('You must supply a valid authentication object'))
 }
 
+function rejectInvalidAuthObjectSync () {
+  return new Error('You must supply a valid authentication object')
+}
+
 function rejectAPIKeyOnBrowser () {
   return Promise.reject(new Error('You cannot use an api key in the browser!'))
+}
+
+function rejectAPIKeyOnBrowserSync () {
+  return new Error('You cannot use an api key in the browser!')
 }
 
 /**
  * Defines the correct authentication
  * method according to the supplied
- * object's properties and returns
+ * object's properties and returns async
  * the builder function.
  *
  * @param {Object} options The object containing
@@ -46,6 +54,26 @@ const strategyBuilder = cond([
   [both(has('email'), has('password')), login.build],
   [has('api_key'), api.build],
   [has('encryption_key'), encryption.build],
+  [has('session_id'), sessionId.build],
+  [T, rejectInvalidAuthObject],
+])
+
+/**
+ * Defines the correct authentication
+ * method according to the supplied
+ * object's properties and returns sync
+ * the builder function.
+ *
+ * @param {Object} options The object containing
+ *                         the authentication data
+ * @return {?Function} The builder function for
+ *                     the Authentication method
+ * @private
+ */
+const strategyBuilderSync = cond([
+  [both(has('email'), has('password')), login.build],
+  [has('api_key'), api.buildSync],
+  [has('encryption_key'), encryption.buildSync],
   [has('session_id'), sessionId.build],
   [T, rejectInvalidAuthObject],
 ])
@@ -73,4 +101,27 @@ function find (options) {
   return Promise.resolve(strategyBuilder(options))
 }
 
-export default { find }
+/**
+ * Finds and returns a builder
+ * function for authentication
+ * according to the supplied object.
+ *
+ * @param {Object} options The object containing
+ *                         the authentication data
+ * @returns {Function} Returns either the
+ *                    correct builder function
+ *                    or throw an Error.
+ */
+function findSync (options) {
+  if (isNil(options)) {
+    throw rejectInvalidAuthObjectSync()
+  }
+
+  if (and(has('api_key', options), isBrowserEnvironment)) {
+    throw rejectAPIKeyOnBrowserSync()
+  }
+
+  return strategyBuilderSync(options)
+}
+
+export default { find, findSync }

--- a/test/runTest.js
+++ b/test/runTest.js
@@ -27,7 +27,7 @@ function testSync (test) {
     options: { baseURL: 'http://127.0.0.1:8080' },
   }
 
-  let syncClient = pagarme.client.connectSync(merge(opts, test.connect))
+  const syncClient = pagarme.client.connectSync(merge(opts, test.connect))
   return test.subject(syncClient)
     .then((response) => {
       expect(response.method).toBe(test.method)
@@ -42,5 +42,3 @@ export default function (test) {
     testSync(test),
   ])
 }
-
- 

--- a/test/runTest.js
+++ b/test/runTest.js
@@ -6,7 +6,7 @@ import pagarme from '..'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000
 
-export default function (test) {
+function testAsync (test) {
   const opts = {
     skipAuthentication: true,
     options: { baseURL: 'http://127.0.0.1:8080' },
@@ -21,3 +21,26 @@ export default function (test) {
     })
 }
 
+function testSync (test) {
+  const opts = {
+    skipAuthentication: true,
+    options: { baseURL: 'http://127.0.0.1:8080' },
+  }
+
+  let syncClient = pagarme.client.connectSync(merge(opts, test.connect))
+  return test.subject(syncClient)
+    .then((response) => {
+      expect(response.method).toBe(test.method)
+      expect(response.url).toBe(test.url)
+      expect(response.body).toMatchObject(test.body)
+    })
+}
+
+export default function (test) {
+  return Promise.all([
+    testAsync(test),
+    testSync(test),
+  ])
+}
+
+ 


### PR DESCRIPTION
## Description

I've heard a couple users complaining about being struggling with connecting to the SDK. (and mainly using chained operations without nesting their promises)
For those used to Promises and async code the lib is pretty straight forward, but since we're dealing also with users coming from other background it's important to make it as easy as possible for them to use the SDK. 

Even though all the SDK is async and promise based it's not required that the setup of the SDK works async, so I've created a connectSync method that will allow users to only connect(setup) synchronously.

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
