### PR TITLE
readme: make Javascript 's' be capitalized

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://avatars1.githubusercontent.com/u/3846050?v=4&s=200" width="127px" height="127px" align="left"/>
 
-# Pagar.me Javascript
+# Pagar.me JavaScript
 
 A JavaScript library to interface with Pagar.me's API, it works in the browser
 and with Node.js.


### PR DESCRIPTION
## Description

In multiple places of the repository the word `JavaScript` is spelled with the `'s'` character capitalized, however in the title of the README.md, it is not. This PR fixes the issue.

### Examples of use in the repository:

#### Repository description
![repository_description_print](https://user-images.githubusercontent.com/15306309/45660646-2e723280-bad0-11e8-8474-9b2d7f9b0e4c.png)

#### Readme description
![readme_description_print](https://user-images.githubusercontent.com/15306309/45660652-3af68b00-bad0-11e8-8fa5-eff7cc07a52b.png)

#### Readme `How to use` section

![readme_how_to_use_section_print](https://user-images.githubusercontent.com/15306309/45660655-3cc04e80-bad0-11e8-9c7d-4437b3a8f294.png)


<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
