### PR TITLE
subscriptions: add settle charge feature

### DIFF
--- a/lib/resources/subscriptions.js
+++ b/lib/resources/subscriptions.js
@@ -142,6 +142,25 @@ const createTransaction = (opts, body) =>
 const findTransactions = (opts, body) =>
   request.get(opts, routes.subscriptions.transactions(body.id), {})
 
+/**
+ * `POST /subscriptions/:id/settle_charge`
+ * Skips the next x charges for a subscription
+ *
+ * @param {Object} opts An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+ * @param {Object} body The payload for the request
+ * {@link https://docs.pagar.me/reference#pulando-cobranças|API Reference for this payload}
+ * @param {Number} body.id The subscription's ID
+ *
+ * @returns {Promise} A promise that resolves to
+ *                    the subscription whose id
+ *                    was passed on the request
+ *                    body or to an error.
+ */
+const settleCharge = (opts, body) =>
+  request.post(opts, routes.subscriptions.settleCharge(body.id), body)
+
 export default {
   all,
   find,
@@ -151,4 +170,5 @@ export default {
   cancel,
   createTransaction,
   findTransactions,
+  settleCharge,
 }

--- a/lib/resources/subscriptions.spec.js
+++ b/lib/resources/subscriptions.spec.js
@@ -113,3 +113,18 @@ test('client.subscriptions.findTransactions', () =>
     },
   })
 )
+
+test('client.subscriptions.settleCharge', () => 
+  runTest({
+    connect: {
+      api_key: 'abc123',
+    },
+    subject: client => client.subscriptions.settleCharge({ id: 5686, charges: 1 }),
+    method: 'POST',
+    url: '/subscriptions/5686/settle_charge',
+    body: {
+      api_key: 'abc123',
+      charges: 1,
+    },
+  })
+)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -104,6 +104,7 @@ const subscriptions = {
   details: id => `/subscriptions/${id}`,
   cancel: id => `/subscriptions/${id}/cancel`,
   transactions: id => `/subscriptions/${id}/transactions`,
+  settleCharge: id => `/subscriptions/${id}/settle_charge`,
 }
 
 const chargebacks = '/chargebacks'


### PR DESCRIPTION
## Description

This PR add the subscriptions settle charge feature to the SDK, as it is on our documentation(https://docs.pagar.me/reference#transa%C3%A7%C3%B5es-em-uma-assinatura).

It also fixes issue #137 .

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
