### PR TITLE
add withVersion method

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -8,6 +8,8 @@
  */
 
 import {
+  assocPath,
+  curry,
   merge,
   map,
   ifElse,
@@ -16,6 +18,34 @@ import {
 
 import strategies from './strategies'
 import resources from '../resources'
+
+const bindOptions = options => func => func.bind(null, options)
+
+const bindRecursive = options => ifElse(
+  is(Function),
+  bindOptions(options),
+  resource => map(bindRecursive(options), resource)
+)
+
+/**
+ * Binds the `options` and `version` received as param
+ * to the client's resources.
+ *
+ * @param {Object} options
+ * @param {Object} version
+ * @returns A version of resources with its methods' first param binded to `options`
+ * and sets the header 'X-PagarMe-Version' to the version passed as param
+ */
+const withVersion = curry((options, version) => {
+  const optionsWithVersion = assocPath(
+    ['headers', 'X-PagarMe-Version'],
+    version,
+    options
+  )
+
+  const boundClientWithVersion = map(bindRecursive(optionsWithVersion), resources)
+  return boundClientWithVersion
+})
 
 /**
  * Binds the `options` received as param
@@ -26,16 +56,15 @@ import resources from '../resources'
  * @returns A version of resources with its methods' first param binded to `options`
  */
 function bindClientOptions ({ options, authentication }) {
-  const bindOptions = func => func.bind(null, options)
+  const boundClient = map(bindRecursive(options), resources)
 
-  const bindRecursive = ifElse(
-    is(Function),
-    bindOptions,
-    resource => map(bindRecursive, resource)
+  return merge(
+    boundClient,
+    {
+      authentication,
+      withVersion: withVersion(options),
+    }
   )
-
-  const boundClient = map(bindRecursive, resources)
-  return merge(boundClient, { authentication })
 }
 
 /**

--- a/lib/resources/index.spec.js
+++ b/lib/resources/index.spec.js
@@ -77,4 +77,23 @@ describe('pagarme.client', () => {
       },
     })
       .then(tap(client => expect(client.authentication.encryption_key).toBe('nwdu91jd9'))))
+
+  test('should set header x-pagarme-version with version passed as param', () => {
+    const opts = {
+      skipAuthentication: true,
+      options: { baseURL: 'http://127.0.0.1:8080' },
+      api_key: 'abc123',
+    }
+    const version = '2019-02-18'
+
+    return pagarme.client.connect(opts)
+      .then(client => client
+        .withVersion(version)
+        .chargebackOperations
+        .find({ transactionId: 1234 })
+      )
+      .then((response) => {
+        expect(response.headers['x-pagarme-version']).toBe(version)
+      })
+  })
 })


### PR DESCRIPTION
## Description

This Pull request adds `.withVersion` method.
This method allows calling a request with a specific version with a chainable API.
example:

```js
client
    .withVersion('2019-02-18')
    .balanceOperations
    .all()
```

When `withVersion` is called the `header` `X-PagarMe-Version` is set to the version passed as param and bound to resources to be called chainable.

resolves #154
