### PR TITLE
transfers: add params in limits request

### DIFF
--- a/lib/resources/transfers.js
+++ b/lib/resources/transfers.js
@@ -112,9 +112,12 @@ const days = opts =>
  * @param {Object} opts An options params which
  *                      is usually already bound
  *                      by `connect` functions.
+ * @param {Object} params The params for the request
+ * @param {String} params.recipient_id The recipient id
+ *
 */
-const limits = opts =>
-  request.get(opts, routes.transfers.limits, {})
+const limits = (opts, params) =>
+  request.get(opts, routes.transfers.limits, params)
 
 export default {
   find,

--- a/lib/resources/transfers.spec.js
+++ b/lib/resources/transfers.spec.js
@@ -95,3 +95,18 @@ test('client.transfers.limits', () =>
     },
   })
 )
+
+test('client.transfers.limits with recipient_id', () =>
+  runTest({
+    connect: {
+      api_key: 'abc123',
+    },
+    subject: client => client.transfers.limits({ recipient_id: 're_11111' }),
+    method: 'GET',
+    url: '/transfers/limits',
+    body: {
+      api_key: 'abc123',
+      recipient_id: 're_11111',
+    },
+  })
+)


### PR DESCRIPTION
Adiciona a possibilitade de passar parametros na request `client.transfers.limits`. Isso é necessário para consegui utilizar como esperado a rota `transfers/limits`.

resolves #165 

### como testar
- verificar o novo teste que foi adicionado
- criar uma request pra `client.transfers.limits({ recipient_id: '<id do recebedor>' })
- verificar se os dados retornam como esperado