### PR TITLE
Add payables days route

### DIFF
--- a/lib/resources/payables.js
+++ b/lib/resources/payables.js
@@ -58,7 +58,19 @@ const find = (opts, body) =>
 const all = (opts, body) =>
   findAll(opts, body)
 
+/**
+ * `GET /payables/days`
+ * Returns a company's payables  aggregated by day
+ *
+ * @param {Object} opts An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+*/
+const days = (opts, body) =>
+  request.get(opts, routes.payables.days, body)
+
 export default {
   find,
   all,
+  days,
 }

--- a/lib/resources/payables.spec.js
+++ b/lib/resources/payables.spec.js
@@ -29,9 +29,26 @@ test('client.transactions.payables', () => {
     url: '/payables/5432',
   }))
 
+  const bodyParams = {
+    end_date: '1559669088459',
+    start_date: '1559064288461',
+    status: ['waiting_funds', 'prepaid'],
+    recipient_id: 're_abc',
+  }
+
+  const findDays = runTest(merge(
+    options,
+    {
+      body: merge(options.body, bodyParams),
+      subject: client => client.payables.days(bodyParams),
+      url: '/payables/days',
+    }
+  ))
+
   return Promise.props({
     findAll,
     findTransaction,
     findOne,
+    findDays,
   })
 })

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -25,6 +25,7 @@ const payables = {
   base: '/payables',
   transaction: transactionId => `/transactions/${transactionId}/payables`,
   find: id => `/payables/${id}`,
+  days: '/payables/days',
 }
 
 const invites = {


### PR DESCRIPTION
## Description
This PR adds a new subroute in payables which brings as result from API a payables summary by day.
Resolves #172

## How to test
1 - Download and build this project.
2 - Create a yarn link using the command `yarn link`.
3 - In the Pilot project(using the branch [`refactor/balance-page`](https://github.com/pagarme/pilot/pull/1236)) use the generated link with the command `yarn link pagarme`.
4 - Acess the balance page and use the filter "A receber".