### PR TITLE
Refactor UserAgent usage

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -11,6 +11,7 @@
 import Promise from 'bluebird'
 import {
   merge,
+  mergeAll,
   length,
   keys,
 } from 'ramda'
@@ -21,12 +22,29 @@ import { version } from '../package.json'
 
 require('isomorphic-fetch')
 
-const userAgent = (navigator && (`${navigator.userAgent} `)) || ''
-
 const defaultHeaders = {
   'Content-Type': 'application/json',
-  'User-Agent': `${userAgent}pagarme-js/${version}`,
-  'X-PagarMe-User-Agent': `${userAgent}pagarme-js/${version}`,
+  'X-PagarMe-User-Agent': `pagarme-js/${version}`,
+}
+
+const isBrowser = typeof window !== 'undefined'
+  && ({}).toString.call(window) === '[object Window]'
+
+const mergeWithDefaultHeaders = (headers) => {
+  if (isBrowser && window.navigator) {
+    const userAgent = window.navigator.userAgent
+      ? `${window.navigator.userAgent} `
+      : ''
+
+    const customAgentHeaders = {
+      'User-Agent': `${userAgent}pagarme-js/${version}`,
+      'X-PagarMe-User-Agent': `${userAgent}pagarme-js/${version}`,
+    }
+
+    return mergeAll([headers, defaultHeaders, customAgentHeaders])
+  }
+
+  return merge(headers, defaultHeaders)
 }
 
 /**
@@ -73,7 +91,7 @@ function buildRequestParams (method, endpoint, options, data) {
 
   if (requestHasBody) {
     body = JSON.stringify(payload)
-    headers = merge(headers, defaultHeaders)
+    headers = mergeWithDefaultHeaders(headers)
     params = {
       method,
       body,


### PR DESCRIPTION
## Description

This PR solves a mistake made in the last version which was using `navigator` directly as a global variable, but this doesn't work in nodejs.

## Linked issues
 - Resolves #179 

## How to test
1 - Download and build this branch
2 - Link this project using `yarn link``
3 - Use the generated link in a node project which uses pagarme-js
4 - Use the same link in a web application ex: [Pilot](https://github.com/pagarme/pilot)

Both projects must work correctly.
