### PR TITLE
Authentication - Add options to login

### DIFF
--- a/lib/client/strategies/login.js
+++ b/lib/client/strategies/login.js
@@ -7,9 +7,8 @@ import { merge } from 'ramda'
 
 import session from '../../resources/session'
 
-const buildSessionAuth = ({ session_id }, headers) => ({
+const buildSessionAuth = ({ session_id }, options) => merge(options, {
   body: { session_id },
-  headers,
 })
 
 /**
@@ -25,14 +24,18 @@ const buildSessionAuth = ({ session_id }, headers) => ({
  *                    the desired `session_id`
  * @private
  */
-function execute ({ email, password, environment }) {
+function execute ({ email, password, environment, options }) {
   const headers = environment === 'live'
     ? { 'X-Live': 1 }
     : {}
 
-  return session.create({ headers }, email, password)
+  const opts = merge(options, {
+    headers,
+  })
+
+  return session.create(opts, email, password)
     .then(sessionInfo => ({
-      options: buildSessionAuth(sessionInfo, headers),
+      options: buildSessionAuth(sessionInfo, opts),
       authentication: sessionInfo,
     }))
 }


### PR DESCRIPTION
## Description
Using any other authentication method (api_key, encryption_key and session_id), we can specify a `options` object. This allows us to change the API's base URL when doing tests locally, however, this `options` parameter is not being used when authenticating with `email` and `password`, which makes it impossible to use the `baseURL` option on frontend projects. This PR fixes that.

## Your checklist for this pull request
- [x] Allows options usage when authenticating with `email` and `password`

Resolves #207