### PR TITLE
company: fix activate request

### DIFF
--- a/lib/resources/company.js
+++ b/lib/resources/company.js
@@ -54,8 +54,8 @@ const createTemporary = (opts, body) =>
  *                    the newly created company's
  *                    data or to an error.
  **/
-const activate = opts =>
-  request.post(opts, routes.company.activate, {})
+const activate = (opts, body) =>
+  request.post(opts, routes.company.activate, body)
 
 /**
  * `PUT /company`


### PR DESCRIPTION
## Description
Fixes the company activate method. It should accept a `body` param, that contains the `token` parameter that will be used to activate the company.

<!--
Things to cite on the PR description:

- Why is the PR needed
- What the PR does
- What are possible side effects
- Additional information (related github issues, links, etc)

  Example: This PR implements feature "x" so we can solve our payments problem. This PR closes #98928312874 (github issue)
-->

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
