### PR TITLE
Adiciona rota de antecipação em acquirer

### DIFF
--- a/lib/resources/acquirers.js
+++ b/lib/resources/acquirers.js
@@ -90,10 +90,29 @@ const create = (opts, body) =>
 const update = (opts, body) =>
   request.put(opts, routes.acquirers.details(body.id), body)
 
+/**
+ * `PUT /acquirers/:id/anticipation_delay/:delay`
+ * Updates an acquirer anticipation from the given delay.
+ *
+ * @param {Object} opts An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+ *
+ * @param {Object} body The payload for the request
+ * @param {Number} body.id The acquirer's ID
+ * @param {Number} body.delay The acquirer's anticipation delay
+ * @returns {Promise} A promise that resolves to
+ *                    the newly created acquirer's
+ *                    data or to an error.
+ */
+const updateAnticipationDelay = (opts, body) =>
+  request.put(opts, routes.acquirers.anticipation(body.id, body.delay), body)
+
 export default {
   all,
   find,
   findAll,
   create,
   update,
+  updateAnticipationDelay,
 }

--- a/lib/resources/acquirers.spec.js
+++ b/lib/resources/acquirers.spec.js
@@ -68,3 +68,17 @@ test('client.acquirers.update', () =>
     },
   })
 )
+
+test('client.acquirers.updateAnticipationDelay', () =>
+  runTest({
+    connect: {
+      api_key: 'abc123',
+    },
+    subject: client => client.acquirers.updateAnticipationDelay({ id: 1234, delay: 1 }),
+    method: 'PUT',
+    url: '/acquirer/1234/anticipation_delay/1',
+    body: {
+      api_key: 'abc123',
+    },
+  })
+)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -99,6 +99,7 @@ const acquirersConfigurations = {
 const acquirers = {
   base: '/acquirers',
   details: id => `/acquirer/${id}`,
+  anticipation: (id, delay) => `/acquirer/${id}/anticipation_delay/${delay}`,
 }
 
 const subscriptions = {


### PR DESCRIPTION
## Description

Adiciona a rota `/acquirer/:id/anticipation_delay/:delay`

- [x] Resolves https://github.com/pagarme/pagarme-js/issues/236