### PR TITLE
Adiciona as rotas de onboarding

### DIFF
--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -29,6 +29,7 @@ import customers from './customers'
 import zipcodes from './zipcodes'
 import paymentLinks from './paymentLinks'
 import status from './status'
+import onboardingAnswers from './onboardingAnswers'
 import onboardingQuestions from './onboardingQuestions'
 import orders from './orders'
 import versions from './versions'
@@ -66,6 +67,7 @@ export default {
   zipcodes,
   paymentLinks,
   status,
+  onboardingAnswers,
   onboardingQuestions,
   orders,
   versions,

--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -29,6 +29,7 @@ import customers from './customers'
 import zipcodes from './zipcodes'
 import paymentLinks from './paymentLinks'
 import status from './status'
+import onboardingQuestions from './onboardingQuestions'
 import orders from './orders'
 import versions from './versions'
 import reprocessedTransactions from './reprocessedTransactions'
@@ -65,6 +66,7 @@ export default {
   zipcodes,
   paymentLinks,
   status,
+  onboardingQuestions,
   orders,
   versions,
   reprocessedTransactions,

--- a/lib/resources/onboardingAnswers.js
+++ b/lib/resources/onboardingAnswers.js
@@ -26,6 +26,21 @@ import request from '../request'
 const create = (opts, body) =>
   request.post(opts, routes.onboardingAnswers.base, body)
 
+/**
+ * `GET /onboarding_answers`
+ * Makes a request to /onboarding_answers to get all answers
+ *
+ * @param {Object} opts An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+ *
+ * @returns {Promise} Resolves to the result of
+ *                    the request or to an error.
+ */
+const all = (opts, body) =>
+  request.get(opts, routes.onboardingAnswers.base, body)
+
 export default {
+  all,
   create,
 }

--- a/lib/resources/onboardingAnswers.js
+++ b/lib/resources/onboardingAnswers.js
@@ -1,0 +1,31 @@
+/**
+ * @name OnboardingAnswers
+ * @description This module exposes functions
+ *              related to the '/onboarding_answers' path.
+ *
+ * @module onboardingAnswers
+ **/
+
+import routes from '../routes'
+import request from '../request'
+
+/**
+ * `POST /onboarding_answers`
+ * Creates a onboarding answer from the given payload.
+ *
+ * @param {Object} opts An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+ *
+ * @param {Object} body The payload for the request.
+ *
+ * @returns {Promise} Resolves to the result of
+ *                    the request or to an error.
+ */
+
+const create = (opts, body) =>
+  request.post(opts, routes.onboardingAnswers.base, body)
+
+export default {
+  create,
+}

--- a/lib/resources/onboardingAnswers.js
+++ b/lib/resources/onboardingAnswers.js
@@ -40,7 +40,24 @@ const create = (opts, body) =>
 const all = (opts, body) =>
   request.get(opts, routes.onboardingAnswers.base, body)
 
+/**
+ * `DELETE /onboarding_answers/:id`
+ * Deletes an onboarding answer
+ *
+ * @param {Object} opts An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+ *
+ * @param {String} [body.id] - The onboarding answer ID.
+ *
+ * @returns {Promise} Resolves to the result of
+ *                    the request or to an error.
+ */
+const destroy = (opts, body) =>
+  request.delete(opts, routes.onboardingAnswers.destroy(body.id), body)
+
 export default {
   all,
   create,
+  destroy,
 }

--- a/lib/resources/onboardingAnswers.spec.js
+++ b/lib/resources/onboardingAnswers.spec.js
@@ -14,3 +14,17 @@ test('client.onboardingAnswers.create', () =>
     },
   })
 )
+
+test('client.onboardingAnswers.all', () =>
+  runTest({
+    connect: {
+      api_key: 'abc123',
+    },
+    subject: client => client.onboardingAnswers.all(),
+    method: 'GET',
+    url: '/onboarding_answers',
+    body: {
+      api_key: 'abc123',
+    },
+  })
+)

--- a/lib/resources/onboardingAnswers.spec.js
+++ b/lib/resources/onboardingAnswers.spec.js
@@ -1,0 +1,16 @@
+import runTest from '../../test/runTest'
+
+test('client.onboardingAnswers.create', () =>
+  runTest({
+    connect: {
+      api_key: 'abc123',
+    },
+    subject: client => client.onboardingAnswers.create({ answer: 'answer' }),
+    method: 'POST',
+    url: '/onboarding_answers',
+    body: {
+      api_key: 'abc123',
+      answer: 'answer',
+    },
+  })
+)

--- a/lib/resources/onboardingAnswers.spec.js
+++ b/lib/resources/onboardingAnswers.spec.js
@@ -28,3 +28,19 @@ test('client.onboardingAnswers.all', () =>
     },
   })
 )
+
+test('client.onboardingAnswers.destroy', () =>
+  runTest({
+    connect: {
+      api_key: 'abc123',
+    },
+    subject: client => client.onboardingAnswers.destroy({
+      id: 1,
+    }),
+    method: 'DELETE',
+    url: '/onboarding_answers/1',
+    body: {
+      api_key: 'abc123',
+    },
+  })
+)

--- a/lib/resources/onboardingQuestions.js
+++ b/lib/resources/onboardingQuestions.js
@@ -1,0 +1,31 @@
+/**
+ * @name OnboardingQuestions
+ * @description This module exposes functions
+ *              related to the '/onboarding_questions' path.
+ *
+ * @module onboardingQuestions
+ **/
+
+import routes from '../routes'
+import request from '../request'
+
+/**
+ * `GET /onboarding_questions/:id`
+ * Return the onboarding question requested.
+ *
+ * @param {Object} opts   An options params which
+ *                        is usually already bound
+ *                        by `connect` functions.
+ *
+ * @param {Object} body The payload for the request
+ * @param {String} body.id The question Id
+ *
+ * @returns {Promise} Resolves to the result of
+ *                    the request or to an error.
+ */
+const find = (opts, body) =>
+  request.get(opts, routes.onboardingQuestions.details(body.id), body)
+
+export default {
+  find,
+}

--- a/lib/resources/onboardingQuestions.spec.js
+++ b/lib/resources/onboardingQuestions.spec.js
@@ -1,0 +1,17 @@
+import runTest from '../../test/runTest'
+
+test('client.onboardingQuestions.find', () =>
+  runTest({
+    connect: {
+      api_key: 'abc123',
+    },
+    subject: client => client.onboardingQuestions.find({
+      id: 1,
+    }),
+    method: 'GET',
+    url: '/onboarding_questions/1',
+    body: {
+      api_key: 'abc123',
+    },
+  })
+)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -182,6 +182,10 @@ const paymentLinks = {
   details: id => `/payment_links/${id}`,
 }
 
+const onboardingQuestions = {
+  details: id => `/onboarding_questions/${id}`,
+}
+
 const orders = {
   base: '/orders',
 }
@@ -211,6 +215,7 @@ export default {
   events,
   gatewayOperations,
   invites,
+  onboardingQuestions,
   orders,
   payables,
   paymentLinks,

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -182,6 +182,10 @@ const paymentLinks = {
   details: id => `/payment_links/${id}`,
 }
 
+const onboardingAnswers = {
+  base: '/onboarding_answers',
+}
+
 const onboardingQuestions = {
   details: id => `/onboarding_questions/${id}`,
 }
@@ -215,6 +219,7 @@ export default {
   events,
   gatewayOperations,
   invites,
+  onboardingAnswers,
   onboardingQuestions,
   orders,
   payables,

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -184,6 +184,7 @@ const paymentLinks = {
 
 const onboardingAnswers = {
   base: '/onboarding_answers',
+  destroy: id => `/onboarding_answers/${id}`,
 }
 
 const onboardingQuestions = {


### PR DESCRIPTION
## Description

Add the resources for the following routes:
- `GET /onboarding_question/:id`
- `GET /onboarding_answers`
- `POST /onboarding_answers`
- `DELETE /onboarding_answers/:id`

Issue: https://github.com/pagarme/credenciamento/issues/472
Related to: https://github.com/pagarme/credenciamento/issues/451

----

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-g:uide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
