### PR TITLE
onboardingAnswers: adjust delete route

### DIFF
--- a/lib/resources/onboardingAnswers.js
+++ b/lib/resources/onboardingAnswers.js
@@ -54,7 +54,7 @@ const all = (opts, body) =>
  *                    the request or to an error.
  */
 const destroy = (opts, body) =>
-  request.delete(opts, routes.onboardingAnswers.destroy(body.id), body)
+  request.delete(opts, routes.onboardingAnswers.base, body)
 
 export default {
   all,

--- a/lib/resources/onboardingAnswers.spec.js
+++ b/lib/resources/onboardingAnswers.spec.js
@@ -35,12 +35,13 @@ test('client.onboardingAnswers.destroy', () =>
       api_key: 'abc123',
     },
     subject: client => client.onboardingAnswers.destroy({
-      id: 1,
+      question_id: 'abc_1',
     }),
     method: 'DELETE',
-    url: '/onboarding_answers/1',
+    url: '/onboarding_answers',
     body: {
       api_key: 'abc123',
+      question_id: 'abc_1',
     },
   })
 )

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -184,7 +184,6 @@ const paymentLinks = {
 
 const onboardingAnswers = {
   base: '/onboarding_answers',
-  destroy: id => `/onboarding_answers/${id}`,
 }
 
 const onboardingQuestions = {


### PR DESCRIPTION
## Description

This PR changes the delete onboardingAnswer delete route from `DELETE /onboarding_answers/:id` to `DELETE /onboarding_answers?question_id=x`.

This changed is needed because it will simplify the logic that will be constructed for the onboarding-pages.

Related to https://github.com/pagarme/credenciamento/issues/482

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
