### PR TITLE
routes: add emailConfirmation route

### DIFF
--- a/lib/resources/company.js
+++ b/lib/resources/company.js
@@ -172,10 +172,28 @@ const emailTemplates = {
     request.put(opts, routes.company.emailTemplates(body.id), body),
 }
 
+
+/**
+ * `POST /company/email_confirmation`
+ * Resend account confirmation email to a previously registered company.
+ *
+ * @param {Object} opts An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+ *
+ * @param {String} body.email The email address to resend the account confirmation
+ * @returns {Promise} A promise that resolves to
+ *                    the send email confirmation company's
+ *                    data or to an error.
+ **/
+const emailConfirmation = (opts, body) =>
+  request.post(opts, routes.company.emailConfirmation, body)
+
 export default {
   create,
   createTemporary,
   activate,
+  emailConfirmation,
   update,
   current,
   resetKeys,

--- a/lib/resources/company.spec.js
+++ b/lib/resources/company.spec.js
@@ -146,3 +146,17 @@ test('client.company.updateBranding', () =>
     },
   })
 )
+
+test('client.company.emailConfirmation', () =>
+  runTest({
+    connect: {
+      api_key: 'abc123',
+    },
+    subject: client => client.company.emailConfirmation({ email: 'teste@pagar.me' }),
+    method: 'POST',
+    url: '/company/email_confirmation',
+    body: {
+      email: 'teste@pagar.me',
+    },
+  })
+)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -63,6 +63,7 @@ const company = {
   basePlural: '/companies',
   base: '/company',
   temporary: '/companies/temporary',
+  emailConfirmation: '/company/email_confirmation',
   activate: '/companies/activate',
   resetKeys: '/company/reset_keys',
   affiliationProgress: '/company/affiliation_progress',


### PR DESCRIPTION
## Description

Este Pr adiciona a rota de `emailConfirmation` para company

## Issues Linkadas
- resolve https://github.com/pagarme/tecnologia-vendas/issues/833

## Como testar
- baixar a branch `add/emai-confirmation-route`
- Executar os tests
- Para Testar localmente
  - Execute `npm run build`
  - Execute `npm pack` isso irá gerar um pacote de arquivo em `.tgz` copie o path e cole no packjson.json do seu projeto ou use o exemplo abaixo

```json
// crie um arquivo package.json
{
  "name": "test",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "dependencies": {
    "pagarme": "COLE O PATH GERADO DO ARQUIVO .tgz AQUI"
  }
}
```


```js
// crie um arquivo index.js
const pagarme = require('pagarme')
pagarme
  .client
  .company
  .emailConfirmation({
    headers: {
      'X-Live': 1,
    }
  }, { "email": "seu-email-para-testar@pagar.me" })
  .then(() => console.log('email de confirmação enviado!'))
  .catch(err => console.log('error', err))
```


