### PR TITLE
Add refund routes

### DIFF
--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -34,6 +34,7 @@ import onboardingQuestions from './onboardingQuestions'
 import orders from './orders'
 import versions from './versions'
 import reprocessedTransactions from './reprocessedTransactions'
+import refunds from './refunds'
 
 export default {
   company,
@@ -72,4 +73,5 @@ export default {
   orders,
   versions,
   reprocessedTransactions,
+  refunds,
 }

--- a/lib/resources/refunds.js
+++ b/lib/resources/refunds.js
@@ -1,0 +1,51 @@
+/**
+ * @name Refunds
+ * @description This module exposes functions
+ *              related to the `/refunds` path.
+ *
+ * @module refunds
+ **/
+
+import { curry } from 'ramda'
+
+import routes from '../routes'
+import request from '../request'
+
+/**
+ * `GET /refunds`
+ * Makes a request to /refunds
+ *
+ * @param {Object} opts - An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+ *
+ * @param {Object} body - The payload for the request.
+ * @param {String} [body.transaction_id] - The refunded transaction ID
+ * @param {String} [body.local_transaction_id] - The refunded transaction external ID
+ * @param {String} [body.metadata] - Metadata used for the refund
+ * @param {String} [body.date_created] - Refund creation date
+ * @param {String} [body.date_updated] - Refund update date
+ */
+const find = curry((opts, body) =>
+  request.get(opts, routes.refunds.base, body)
+)
+
+/**
+ * `POST /refunds/:id/cancel`
+ * Makes a request to /refunds/:id/cancel
+ *
+ * @param {Object} opts - An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+ *
+ * @param {Object} body - The payload for the request.
+ * @param {String} [body.id] - The ID of the refund to be canceled
+ */
+const cancel = curry((opts, body) =>
+  request.post(opts, routes.refunds.cancel(body.id))
+)
+
+export default {
+  cancel,
+  find,
+}

--- a/lib/resources/refunds.spec.js
+++ b/lib/resources/refunds.spec.js
@@ -1,0 +1,34 @@
+import Promise from 'bluebird'
+import { merge } from 'ramda'
+
+import runTest from '../../test/runTest'
+
+const findOptions = {
+  connect: {
+    api_key: 'abc123',
+  },
+  body: {
+    api_key: 'abc123',
+  },
+}
+
+test('client.refunds.find', () => {
+  const find = runTest(merge(findOptions, {
+    subject: client => client.refunds.find({ transaction_id: 11 }),
+    url: '/refunds',
+    method: 'GET',
+  }))
+
+  return Promise.props({
+    find,
+  })
+})
+
+test('client.refunds.cancel', () =>
+  runTest(merge({
+    subject: client => client.refunds.cancel({ id: 1234 }),
+    url: '/refunds/1234/cancel',
+    method: 'POST',
+  }, findOptions))
+)
+

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -196,6 +196,11 @@ const orders = {
   base: '/orders',
 }
 
+const refunds = {
+  base: '/refunds',
+  cancel: id => `/refunds/${id}/cancel`,
+}
+
 const companySegments = '/company_segments'
 
 const status = '/status'
@@ -241,4 +246,5 @@ export default {
   status,
   versions,
   reprocessedTransactions,
+  refunds,
 }


### PR DESCRIPTION
## Description
To be able to search for and cancel refunds, we need the following routes:
- `GET /refunds`
- `POST /refunds/:id/cancel`

Although we won't use refund cancel route for now, on this pull request I am adding both

## Your checklist for this pull request
- [x] Adds `GET /refunds` resource with the supported query params
- [x] Adds `POST /refunds/:id/cancel` resource

Resolves https://github.com/pagarme/pagarme-js/issues/261
