### PR TITLE
Permite enviar parâmetros na busca por transações de assinaturas

### DIFF
--- a/lib/resources/subscriptions.js
+++ b/lib/resources/subscriptions.js
@@ -140,7 +140,7 @@ const createTransaction = (opts, body) =>
  *                    the request or to an error.
  */
 const findTransactions = (opts, body) =>
-  request.get(opts, routes.subscriptions.transactions(body.id), {})
+  request.get(opts, routes.subscriptions.transactions(body.id), body)
 
 /**
  * `POST /subscriptions/:id/settle_charge`

--- a/lib/resources/subscriptions.spec.js
+++ b/lib/resources/subscriptions.spec.js
@@ -105,11 +105,18 @@ test('client.subscriptions.findTransactions', () =>
     connect: {
       api_key: 'abc123',
     },
-    subject: client => client.subscriptions.findTransactions({ id: 5686 }),
+    subject: client => client.subscriptions.findTransactions({
+      id: 5686,
+      count: 10,
+      page: 10,
+    }),
     method: 'GET',
     url: '/subscriptions/5686/transactions',
     body: {
       api_key: 'abc123',
+      id: '5686',
+      page: '10',
+      count: '10',
     },
   })
 )


### PR DESCRIPTION
## Description

Resolve o problema da issue https://github.com/pagarme/pagarme-js/issues/269

Com essa alteração será possível enviar os parâmetros `count` e `page` na rota `subscriptions/:id/transactions`

Dúvida: Preciso commitar os arquivos alterados com `yarn build`?

## Your checklist for this pull request

:rotating_light: Please review this items for a good pull request. :four_leaf_clover:

1. I've read the project's [Contributing Guidelines](CONTRIBUTING.md)
1. My commits are well written and follow [pagarme/git-style-guide](https://github.com/pagarme/git-style-guide)
1. My changes are well covered by **tests** and **logs**
1. I've updated the project docs (if needed)
1. I fell safe about this implementation

In a good pull request, everything above is true :relaxed:
