### PR TITLE
EXP-640 Adicionar rota /pix/keys ao pagarme-js

### DIFF
--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -28,7 +28,7 @@ import security from './security'
 import customers from './customers'
 import zipcodes from './zipcodes'
 import paymentLinks from './paymentLinks'
-import pix from './pix'
+import pixKeys from './pix'
 import status from './status'
 import onboardingAnswers from './onboardingAnswers'
 import onboardingQuestions from './onboardingQuestions'
@@ -46,7 +46,7 @@ export default {
   session,
   transactions,
   payables,
-  pix,
+  pixKeys,
   user,
   invites,
   splitRules,

--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -28,6 +28,7 @@ import security from './security'
 import customers from './customers'
 import zipcodes from './zipcodes'
 import paymentLinks from './paymentLinks'
+import pix from './pix'
 import status from './status'
 import onboardingAnswers from './onboardingAnswers'
 import onboardingQuestions from './onboardingQuestions'
@@ -45,6 +46,7 @@ export default {
   session,
   transactions,
   payables,
+  pix,
   user,
   invites,
   splitRules,

--- a/lib/resources/pix.js
+++ b/lib/resources/pix.js
@@ -1,0 +1,20 @@
+/**
+ * @name Pix
+ * @description This module exposes functions
+ *              related to the `/pix` path.
+ *
+ * @module balanceOperations
+ **/
+import routes from '../routes'
+import request from '../request'
+
+const createKey = (opts, body) =>
+  request.post(opts, routes.pix.keys, body || {})
+
+const getKeys = opts =>
+  request.get(opts, routes.pix.keys)
+
+export default {
+  createKey,
+  getKeys,
+}

--- a/lib/resources/pix.js
+++ b/lib/resources/pix.js
@@ -1,16 +1,37 @@
 /**
- * @name Pix
+ * @name PixKeys
  * @description This module exposes functions
  *              related to the `/pix` path.
  *
- * @module balanceOperations
+ * @module pixKeys
  **/
 import routes from '../routes'
 import request from '../request'
 
+/**
+ * `POST /pix/key`
+ * Creates a pix from the given payload.
+ *
+ * @param {Object} opts An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+ * @param {Object} body The payload for the request
+ *
+ * @returns {Promise} Resolves to the result of
+ *                    the request or to an error.
+ */
 const create = (opts, body) =>
   request.post(opts, routes.pix.keys, body || {})
 
+/**
+* `GET /pix/keys`
+* Makes a request to /pix/keys
+*
+* @param {Object} opts - An options params which
+*                      is usually already bound
+*                      by `connect` functions.
+*
+*/
 const all = opts =>
   request.get(opts, routes.pix.keys)
 

--- a/lib/resources/pix.js
+++ b/lib/resources/pix.js
@@ -8,13 +8,13 @@
 import routes from '../routes'
 import request from '../request'
 
-const createKey = (opts, body) =>
+const create = (opts, body) =>
   request.post(opts, routes.pix.keys, body || {})
 
-const getKeys = opts =>
+const all = opts =>
   request.get(opts, routes.pix.keys)
 
 export default {
-  createKey,
-  getKeys,
+  create,
+  all,
 }

--- a/lib/resources/pix.spec.js
+++ b/lib/resources/pix.spec.js
@@ -1,0 +1,32 @@
+import runTest from '../../test/runTest'
+
+test('client.pix.createKey', () =>
+  runTest({
+    connect: {
+      api_key: 'abc123',
+    },
+    subject: client =>
+      client.pix.createKey({ recipient_id: 'abc_123' }),
+    method: 'POST',
+    url: '/pix/keys',
+    body: {
+      api_key: 'abc123',
+      recipient_id: 'abc_123',
+    },
+  })
+)
+
+test('client.pix.getKeys', () =>
+  runTest({
+    connect: {
+      api_key: 'abc123',
+    },
+    subject: client =>
+      client.pix.getKeys(),
+    method: 'GET',
+    url: '/pix/keys',
+    body: {
+      api_key: 'abc123',
+    },
+  })
+)

--- a/lib/resources/pix.spec.js
+++ b/lib/resources/pix.spec.js
@@ -1,12 +1,12 @@
 import runTest from '../../test/runTest'
 
-test('client.pix.createKey', () =>
+test('client.pixKeys.createKey', () =>
   runTest({
     connect: {
       api_key: 'abc123',
     },
     subject: client =>
-      client.pix.createKey({ recipient_id: 'abc_123' }),
+      client.pixKeys.create({ recipient_id: 'abc_123' }),
     method: 'POST',
     url: '/pix/keys',
     body: {
@@ -16,13 +16,13 @@ test('client.pix.createKey', () =>
   })
 )
 
-test('client.pix.getKeys', () =>
+test('client.pixKeys.getKeys', () =>
   runTest({
     connect: {
       api_key: 'abc123',
     },
     subject: client =>
-      client.pix.getKeys(),
+      client.pixKeys.all(),
     method: 'GET',
     url: '/pix/keys',
     body: {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -217,6 +217,11 @@ const feePresets = {
   details: id => `/fee_presets/${id}`,
 }
 
+const pix = {
+  base: '/pix',
+  keys: '/pix/keys',
+}
+
 export default {
   acquirers,
   chargebacks,
@@ -240,6 +245,7 @@ export default {
   orders,
   payables,
   paymentLinks,
+  pix,
   plans,
   postbacks,
   recipients,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagarme",
-  "version": "4.15.3",
+  "version": "4.16.0",
   "description": "A JavaScript library to interface with Pagar.me API",
   "main": "pagarme.js",
   "scripts": {


### PR DESCRIPTION
## Description

Esse PR adiciona a rota `GET /pix/keys` e `POST /pix/keys`. Com ela, será possivel retornar todas as chaves ativas de uma company no serviço PIX e gerar novas chaves. 

### Como utilizar
- `client.pix.create({ recipient_id: 'abc' })`
- `client.pix.all()`

