### PR TITLE
EXP-751 mapear rota GET /recipient/:id/settlements

### DIFF
--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -37,6 +37,7 @@ import versions from './versions'
 import reprocessedTransactions from './reprocessedTransactions'
 import refunds from './refunds'
 import feePresets from './feePresets'
+import settlements from './settlements'
 
 export default {
   company,
@@ -70,6 +71,7 @@ export default {
   customers,
   zipcodes,
   paymentLinks,
+  settlements,
   status,
   onboardingAnswers,
   onboardingQuestions,

--- a/lib/resources/settlements.js
+++ b/lib/resources/settlements.js
@@ -1,0 +1,29 @@
+/**
+ * @name settlements
+ * @description This module exposes functions
+ *              related to the `/recipient/:id/settlements` path.
+ *
+ * @module settlements
+ **/
+import routes from '../routes'
+import request from '../request'
+
+/**
+ * `GET /recipients/:id/settlements`
+ * Get settlements for a specfic recipient.
+ *
+ * @param {Object} opts An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+ * @param {String} [body.recipientId] - The ID of the recipient
+ *
+  *
+ * @param {Object} body https://docs.pagar.me/reference?showHidden=7e035#retornando-pagamentos.
+ *
+ * @returns {Promise} Resolves to the result of
+ *                    the request or to an error.
+ */
+const all = (opts, body) =>
+  request.get(opts, routes.settlements(body.recipientId), body)
+
+export default all

--- a/lib/resources/settlements.spec.js
+++ b/lib/resources/settlements.spec.js
@@ -1,0 +1,25 @@
+import { merge } from 'ramda'
+import runTest from '../../test/runTest'
+
+const findOptions = {
+  connect: {
+    api_key: 'abc123',
+  },
+  body: {
+    api_key: 'abc123',
+  },
+}
+
+test('client.settlements.get', () =>
+  runTest(merge({
+    subject: client =>
+      client.settlements({
+        recipientId: 'abc_123',
+        query: {
+          page: 1,
+          count: 1,
+        } }),
+    method: 'GET',
+    url: '/recipients/abc_123/settlements',
+  }, findOptions))
+)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -222,6 +222,8 @@ const pix = {
   keys: '/pix/keys',
 }
 
+const settlements = recipientId => `/recipients/${recipientId}/settlements`
+
 export default {
   acquirers,
   chargebacks,
@@ -251,6 +253,7 @@ export default {
   recipients,
   search,
   session,
+  settlements,
   splitRules,
   subscriptions,
   transactions,


### PR DESCRIPTION
## Description
Adicionado rota para trazer todos os settlements de um recipient

## Your checklist for this pull request

- [ ] mapear rota GET /recipient/:id/settlements
- [ ] client.settlements(recipientId, query)