### PR TITLE
EXP-767 mapear a rota GET /recipients/:recipientId/settlements/contracts 

### DIFF
--- a/lib/resources/settlements.js
+++ b/lib/resources/settlements.js
@@ -24,6 +24,8 @@ import request from '../request'
  *                    the request or to an error.
  */
 const all = (opts, body) =>
-  request.get(opts, routes.settlements(body.recipientId), body)
+  request.get(opts, routes.settlements.all(body.recipientId), body)
 
-export default all
+export default {
+  all,
+}

--- a/lib/resources/settlements.js
+++ b/lib/resources/settlements.js
@@ -26,6 +26,28 @@ import request from '../request'
 const all = (opts, body) =>
   request.get(opts, routes.settlements.all(body.recipientId), body)
 
+/**
+ * `GET /recipients/:id/settlements/contracts`
+ * Get settlements for a specfic recipient.
+ *
+ * @param {Object} opts An options params which
+ *                      is usually already bound
+ *                      by `connect` functions.
+ * @param {String} [body.recipientId] - The ID of the recipient
+ *
+  *
+ * @param {Object} body https://docs.pagar.me/reference?showHidden=7e035#retornando-pagamentos.
+ *
+ * @returns {Promise} Resolves to the result of
+ *                    the request or to an error.
+ */
+const contractsAll = (opts, body) =>
+  request.get(opts, routes.settlements.contracts.all(body.recipientId), body)
+
+
 export default {
   all,
+  contracts: {
+    all: contractsAll,
+  },
 }

--- a/lib/resources/settlements.spec.js
+++ b/lib/resources/settlements.spec.js
@@ -15,11 +15,23 @@ test('client.settlements.all', () =>
     subject: client =>
       client.settlements.all({
         recipientId: 'abc_123',
-        query: {
-          page: 1,
-          count: 1,
-        } }),
+        page: 1,
+        count: 1,
+      }),
     method: 'GET',
     url: '/recipients/abc_123/settlements',
+  }, findOptions))
+)
+
+test('client.settlements.contracts.all', () =>
+  runTest(merge({
+    subject: client =>
+      client.settlements.contracts.all({
+        recipientId: 'abc_123',
+        page: 1,
+        count: 1,
+      }),
+    method: 'GET',
+    url: '/recipients/abc_123/settlements/contracts',
   }, findOptions))
 )

--- a/lib/resources/settlements.spec.js
+++ b/lib/resources/settlements.spec.js
@@ -10,10 +10,10 @@ const findOptions = {
   },
 }
 
-test('client.settlements.get', () =>
+test('client.settlements.all', () =>
   runTest(merge({
     subject: client =>
-      client.settlements({
+      client.settlements.all({
         recipientId: 'abc_123',
         query: {
           page: 1,

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -224,6 +224,9 @@ const pix = {
 
 const settlements = {
   all: recipientId => `/recipients/${recipientId}/settlements`,
+  contracts: {
+    all: recipientId => `/recipients/${recipientId}/settlements/contracts`,
+  },
 }
 
 export default {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -222,7 +222,9 @@ const pix = {
   keys: '/pix/keys',
 }
 
-const settlements = recipientId => `/recipients/${recipientId}/settlements`
+const settlements = {
+  all: recipientId => `/recipients/${recipientId}/settlements`,
+}
 
 export default {
   acquirers,


### PR DESCRIPTION
## Description

Esse PR adiciona a rota de contratos externos nas liquidações. Alteração no rota de `client.settlements()`  para `client.settlements.all()`.

## Como testar
- Verificar se as rotas `client.settlements.all()` está sendo chamado corretamente
- Verificar se as rotas `client.settlements.contracts.all()` está sendo chamado corretamente
