### PR TITLE
[EXP-787] Criar estratégia de login com jwt + account_id

### DIFF
--- a/lib/client/strategies/index.js
+++ b/lib/client/strategies/index.js
@@ -19,6 +19,7 @@ import encryption from './encryption'
 import login from './login'
 import api from './api'
 import sessionId from './sessionId'
+import jwt from './jwt'
 
 const isBrowserEnvironment = typeof global === 'undefined'
 
@@ -47,6 +48,7 @@ const strategyBuilder = cond([
   [has('api_key'), api.build],
   [has('encryption_key'), encryption.build],
   [has('session_id'), sessionId.build],
+  [both(has('account_id'), has('jwt')), jwt.build],
   [T, rejectInvalidAuthObject],
 ])
 

--- a/lib/client/strategies/jwt.js
+++ b/lib/client/strategies/jwt.js
@@ -1,0 +1,73 @@
+/**
+ * @name sessionId
+ * @memberof strategies
+ * @private
+ */
+import { reject, resolve } from 'bluebird'
+import { merge } from 'ramda'
+import transactions from '../../resources/transactions'
+
+/**
+ * Creates an object with
+ * the `account_id` and `jwt`from
+ * the supplied `options` param
+ *
+ * @param {any} options
+ * @returns {Object} an object containing
+ *                   a body property with
+ *                   the desired `jwt`
+ * @private
+ */
+function execute ({
+  account_id: accountId,
+  environment,
+  impersonationKey,
+  jwt,
+  options,
+  skipAuthentication,
+}) {
+  const headers = environment === 'live'
+    ? { 'X-Live': 1 }
+    : {}
+
+  const body = {
+    account_id: accountId,
+    jwt,
+  }
+
+  if (impersonationKey) {
+    body.impersonation_key = impersonationKey
+  }
+
+  const opts = merge(options, {
+    body,
+    headers,
+  })
+
+  return transactions.calculateInstallmentsAmount(
+    opts, { amount: 1, interest_rate: 100 }
+  )
+    .catch(error => (skipAuthentication ? resolve(opts) : reject(error)))
+    .catch({ name: 'ApiError' }, () => reject(new Error('You must supply a valid jwt token and a valid account_id')))
+    .then(() => ({
+      authentication: { account_id: accountId, jwt },
+      options: opts,
+    }))
+}
+
+/**
+ * Returns the supplied parameter with
+ * the `execute` function added to it.
+ *
+ * @param {any} options
+ * @returns {Object} The `options` parameter
+ *                   with `execute` add to it
+ * @private
+ */
+function build (options) {
+  return merge(options, { execute: execute.bind(null, options) })
+}
+
+export default {
+  build,
+}


### PR DESCRIPTION
## Contexto

Esse PR tem o objetivo de criar uma nova estratégia de login utilizando o jwt + acocunt_id.

## Como testar?
- buildar o projeto nesta branch.
- tentar fazer o login da seguinte forma:
`pagarme.client.connect({
    jwt: 'jwt token aqui',
   account_id: 'account id aqui'
})`
- Verificar que o login foi feito com sucesso e que é possível utilizar esses dados para fazer requests.

OBS: Explicações de como conseguir o token jwt e o account_id se encontram na issue do jira.
