### PR TITLE
fix: card_expiration_date validation test

### DIFF
--- a/lib/validations/index.spec.js
+++ b/lib/validations/index.spec.js
@@ -1,5 +1,11 @@
 import validate from './index'
 
+const getNextYear = () => {
+  const today = new Date()
+  const currentYear = parseInt(today.getFullYear().toString().substr(2, 2), 10)
+  return currentYear + 1
+}
+
 describe('validator', () => {
   it('should validate fields', () => {
     const data = {
@@ -12,7 +18,7 @@ describe('validator', () => {
         card_holder_name: 'Marco Worms',
         card_number: '5545497548400992',
         card_cvv: 856,
-        card_expiration_date: '11/21',
+        card_expiration_date: `11/${getNextYear()}`,
       },
     }
     const result = validate(data)


### PR DESCRIPTION
## Description
- O teste que testava a validação de card_expiration_date estava com uma uma data fixa e que fazia o teste só ser válido até mês passado. Agora ele sempre vai pegar o ano atual + 1

## Como testar
- Rodar os testes e ver se estão passando
