### PR TITLE
[EXP-1076] Remove id do body da chamada subscriptions.findTransactions

### DIFF
--- a/lib/resources/subscriptions.js
+++ b/lib/resources/subscriptions.js
@@ -6,7 +6,7 @@
  * @module subscriptions
  **/
 
-import { cond, has, T, curry } from 'ramda'
+import { cond, has, T, curry, omit } from 'ramda'
 
 import routes from '../routes'
 import request from '../request'
@@ -140,7 +140,7 @@ const createTransaction = (opts, body) =>
  *                    the request or to an error.
  */
 const findTransactions = (opts, body) =>
-  request.get(opts, routes.subscriptions.transactions(body.id), body)
+  request.get(opts, routes.subscriptions.transactions(body.id), omit(['id'], body))
 
 /**
  * `POST /subscriptions/:id/settle_charge`

--- a/lib/resources/subscriptions.spec.js
+++ b/lib/resources/subscriptions.spec.js
@@ -114,7 +114,6 @@ test('client.subscriptions.findTransactions', () =>
     url: '/subscriptions/5686/transactions',
     body: {
       api_key: 'abc123',
-      id: '5686',
       page: '10',
       count: '10',
     },


### PR DESCRIPTION
## Description
 - Remove id do body da chamada subscriptions.findTransactions
## Como testar
- Linkar esse PR com o PR da pilot de detalhes de subscription
- Impersonar na pilot com uma company que tenha subscription
- verificar se a chamada da lista de transações funcionou corretamente